### PR TITLE
Fix clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,94 +1,12 @@
----
-Language:        Cpp
-# BasedOnStyle:  Mozilla
-AccessModifierOffset: -2
-AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
-AlignEscapedNewlinesLeft: false
-AlignOperands:   true
+BasedOnStyle: Chromium
 AlignTrailingComments: true
-AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortBlocksOnASingleLine: false
-AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: Inline
-AllowShortIfStatementsOnASingleLine: false
-AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterDefinitionReturnType: TopLevel
-AlwaysBreakAfterReturnType: TopLevelDefinitions
-AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: true
-BinPackArguments: true
-BinPackParameters: true
-BraceWrapping:   
-  AfterClass:      true
-  AfterControlStatement: false
-  AfterEnum:       true
-  AfterFunction:   true
-  AfterNamespace:  false
-  AfterObjCDeclaration: false
-  AfterStruct:     true
-  AfterUnion:      true
-  BeforeCatch:     false
-  BeforeElse:      false
-  IndentBraces:    false
-BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Mozilla
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: true
-BreakAfterJavaFieldAnnotations: false
-BreakStringLiterals: true
-ColumnLimit:     80
-CommentPragmas:  '^ IWYU pragma:'
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
-ConstructorInitializerIndentWidth: 2
-ContinuationIndentWidth: 2
-Cpp11BracedListStyle: false
-DerivePointerAlignment: false
-DisableFormat:   false
-ExperimentalAutoDetectBinPacking: false
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
-IncludeCategories: 
-  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
-    Priority:        2
-  - Regex:           '^(<|"(gtest|isl|json)/)'
-    Priority:        3
-  - Regex:           '.*'
-    Priority:        1
-IncludeIsMainRegex: '$'
-IndentCaseLabels: true
-IndentWidth:     2
-IndentWrappedFunctionNames: false
-KeepEmptyLinesAtTheStartOfBlocks: true
-MacroBlockBegin: ''
-MacroBlockEnd:   ''
-MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
-ObjCBlockIndentWidth: 2
+BreakBeforeBraces: Allman
+ColumnLimit: 0
+IndentWidth: 2
+KeepEmptyLinesAtTheStartOfBlocks: false
 ObjCSpaceAfterProperty: true
-ObjCSpaceBeforeProtocolList: false
-PenaltyBreakBeforeFirstCallParameter: 19
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakString: 1000
-PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 200
-PointerAlignment: Left
-ReflowComments:  true
-SortIncludes:    true
-SpaceAfterCStyleCast: false
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeParens: ControlStatements
-SpaceInEmptyParentheses: false
+ObjCSpaceBeforeProtocolList: true
+PointerBindsToType: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
-SpacesInContainerLiterals: true
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
-Standard:        Cpp11
-TabWidth:        8
-UseTab:          Never
-JavaScriptQuotes: Leave
-...
-
+TabWidth: 8
+UseTab: Never

--- a/AssimpKit/Code/Model/AssimpImporter.h
+++ b/AssimpKit/Code/Model/AssimpImporter.h
@@ -13,6 +13,6 @@
 
 @interface AssimpImporter : NSObject
 
-- (SCNAssimpScene*)importScene:(NSString*)filePath;
+- (SCNAssimpScene *)importScene:(NSString *)filePath;
 
 @end

--- a/AssimpKit/Code/Model/AssimpImporter.m
+++ b/AssimpKit/Code/Model/AssimpImporter.m
@@ -14,15 +14,14 @@
 #include "assimp/postprocess.h" // Post processing flags
 #include "assimp/scene.h"       // Output data structure
 
-@interface
-AssimpImporter ()
+@interface AssimpImporter ()
 
-@property (readwrite, nonatomic) NSMutableArray* boneNames;
-@property (readwrite, nonatomic) NSArray* uniqueBoneNames;
-@property (readwrite, nonatomic) NSArray* uniqueBoneNodes;
-@property (readwrite, nonatomic) NSMutableDictionary* boneTransforms;
-@property (readwrite, nonatomic) NSArray* uniqueBoneTransforms;
-@property (readwrite, nonatomic) SCNNode* skelton;
+@property (readwrite, nonatomic) NSMutableArray *boneNames;
+@property (readwrite, nonatomic) NSArray *uniqueBoneNames;
+@property (readwrite, nonatomic) NSArray *uniqueBoneNodes;
+@property (readwrite, nonatomic) NSMutableDictionary *boneTransforms;
+@property (readwrite, nonatomic) NSArray *uniqueBoneTransforms;
+@property (readwrite, nonatomic) SCNNode *skelton;
 
 @end
 
@@ -31,7 +30,8 @@ AssimpImporter ()
 - (id)init
 {
   self = [super init];
-  if (self) {
+  if (self)
+  {
     self.boneNames = [[NSMutableArray alloc] init];
     self.boneTransforms = [[NSMutableDictionary alloc] init];
     return self;
@@ -41,22 +41,24 @@ AssimpImporter ()
 
 #pragma mark - Import with Assimp
 
-- (SCNAssimpScene*)importScene:(NSString*)filePath
+- (SCNAssimpScene *)importScene:(NSString *)filePath
 {
   // Start the import on the given file with some example postprocessing
   // Usually - if speed is not the most important aspect for you - you'll t
   // probably to request more postprocessing than we do in this example.
-  const char* pFile = [filePath UTF8String];
-  const struct aiScene* aiScene =
-    aiImportFile(pFile, aiProcess_FlipUVs | aiProcess_Triangulate);
+  const char *pFile = [filePath UTF8String];
+  const struct aiScene *aiScene =
+      aiImportFile(pFile, aiProcess_FlipUVs | aiProcess_Triangulate);
   // If the import failed, report it
-  if (!aiScene) {
+  if (!aiScene)
+  {
     NSLog(@" Scene importing failed for filePath %@", filePath);
     return nil;
   }
   // Now we can access the file's contents
-  SCNAssimpScene* scene =
-    [self makeSCNSceneFromAssimpScene:aiScene atPath:filePath];
+  SCNAssimpScene *scene =
+      [self makeSCNSceneFromAssimpScene:aiScene
+                                 atPath:filePath];
   // We're done. Release all resources associated with this import
   aiReleaseImport(aiScene);
   return scene;
@@ -64,19 +66,21 @@ AssimpImporter ()
 
 #pragma mark - Make SCN Scene
 
-- (SCNAssimpScene*)makeSCNSceneFromAssimpScene:(const struct aiScene*)aiScene
-                                        atPath:(NSString*)path
+- (SCNAssimpScene *)makeSCNSceneFromAssimpScene:(const struct aiScene *)aiScene
+                                         atPath:(NSString *)path
 {
   NSLog(@" Make an SCNScene");
-  const struct aiNode* aiRootNode = aiScene->mRootNode;
-  SCNAssimpScene* scene = [[SCNAssimpScene alloc] init];
+  const struct aiNode *aiRootNode = aiScene->mRootNode;
+  SCNAssimpScene *scene = [[SCNAssimpScene alloc] init];
   /*
    -------------------------------------------------------------------
    Assign geometry, materials, lights and cameras to the node
    ---------------------------------------------------------------------
    */
-  SCNNode* scnRootNode =
-    [self makeSCNNodeFromAssimpNode:aiRootNode inScene:aiScene atPath:path];
+  SCNNode *scnRootNode =
+      [self makeSCNNodeFromAssimpNode:aiRootNode
+                              inScene:aiScene
+                               atPath:path];
   [scene.rootNode addChildNode:scnRootNode];
   /*
    ---------------------------------------------------------------------
@@ -92,12 +96,12 @@ AssimpImporter ()
 
 #pragma mark - Make SCN Node
 
-- (SCNNode*)makeSCNNodeFromAssimpNode:(const struct aiNode*)aiNode
-                              inScene:(const struct aiScene*)aiScene
-                               atPath:(NSString*)path
+- (SCNNode *)makeSCNNodeFromAssimpNode:(const struct aiNode *)aiNode
+                               inScene:(const struct aiScene *)aiScene
+                                atPath:(NSString *)path
 {
-  SCNNode* node = [[SCNNode alloc] init];
-  const struct aiString* aiNodeName = &aiNode->mName;
+  SCNNode *node = [[SCNNode alloc] init];
+  const struct aiString *aiNodeName = &aiNode->mName;
   node.name = [NSString stringWithUTF8String:aiNodeName->data];
   NSLog(@" Creating node %@ with %d meshes", node.name, aiNode->mNumMeshes);
   int nVertices = [self findNumVerticesInNode:aiNode inScene:aiScene];
@@ -110,28 +114,31 @@ AssimpImporter ()
   [self.boneNames addObjectsFromArray:[self getBoneNamesForAssimpNode:aiNode
                                                               inScene:aiScene]];
   [self.boneTransforms
-    addEntriesFromDictionary:[self getBoneTransformsForAssimpNode:aiNode
-                                                          inScene:aiScene]];
+      addEntriesFromDictionary:[self getBoneTransformsForAssimpNode:aiNode
+                                                            inScene:aiScene]];
 
   // ---------
   // TRANSFORM
   // ---------
   const struct aiMatrix4x4 aiNodeMatrix = aiNode->mTransformation;
   GLKMatrix4 glkNodeMatrix = GLKMatrix4Make(
-    aiNodeMatrix.a1, aiNodeMatrix.b1, aiNodeMatrix.c1, aiNodeMatrix.d1,
-    aiNodeMatrix.a2, aiNodeMatrix.b2, aiNodeMatrix.c2, aiNodeMatrix.d2,
-    aiNodeMatrix.a3, aiNodeMatrix.b3, aiNodeMatrix.c3, aiNodeMatrix.d3,
-    aiNodeMatrix.a4, aiNodeMatrix.b4, aiNodeMatrix.c4, aiNodeMatrix.d4);
+      aiNodeMatrix.a1, aiNodeMatrix.b1, aiNodeMatrix.c1, aiNodeMatrix.d1,
+      aiNodeMatrix.a2, aiNodeMatrix.b2, aiNodeMatrix.c2, aiNodeMatrix.d2,
+      aiNodeMatrix.a3, aiNodeMatrix.b3, aiNodeMatrix.c3, aiNodeMatrix.d3,
+      aiNodeMatrix.a4, aiNodeMatrix.b4, aiNodeMatrix.c4, aiNodeMatrix.d4);
 
   SCNMatrix4 scnMatrix = SCNMatrix4FromGLKMatrix4(glkNodeMatrix);
   node.transform = scnMatrix;
   NSLog(@" Node %@ position %f %f %f", node.name, aiNodeMatrix.a4,
         aiNodeMatrix.b4, aiNodeMatrix.c4);
 
-  for (int i = 0; i < aiNode->mNumChildren; i++) {
-    const struct aiNode* aiChildNode = aiNode->mChildren[i];
-    SCNNode* childNode =
-      [self makeSCNNodeFromAssimpNode:aiChildNode inScene:aiScene atPath:path];
+  for (int i = 0; i < aiNode->mNumChildren; i++)
+  {
+    const struct aiNode *aiChildNode = aiNode->mChildren[i];
+    SCNNode *childNode =
+        [self makeSCNNodeFromAssimpNode:aiChildNode
+                                inScene:aiScene
+                                 atPath:path];
     [node addChildNode:childNode];
   }
   return node;
@@ -139,37 +146,40 @@ AssimpImporter ()
 
 #pragma mark - Number of vertices, faces and indices
 
-- (int)findNumVerticesInNode:(const struct aiNode*)aiNode
-                     inScene:(const struct aiScene*)aiScene
+- (int)findNumVerticesInNode:(const struct aiNode *)aiNode
+                     inScene:(const struct aiScene *)aiScene
 {
   int nVertices = 0;
-  for (int i = 0; i < aiNode->mNumMeshes; i++) {
+  for (int i = 0; i < aiNode->mNumMeshes; i++)
+  {
     int aiMeshIndex = aiNode->mMeshes[i];
-    const struct aiMesh* aiMesh = aiScene->mMeshes[aiMeshIndex];
+    const struct aiMesh *aiMesh = aiScene->mMeshes[aiMeshIndex];
     nVertices += aiMesh->mNumVertices;
   }
   return nVertices;
 }
 
-- (int)findNumFacesInNode:(const struct aiNode*)aiNode
-                  inScene:(const struct aiScene*)aiScene
+- (int)findNumFacesInNode:(const struct aiNode *)aiNode
+                  inScene:(const struct aiScene *)aiScene
 {
   int nFaces = 0;
-  for (int i = 0; i < aiNode->mNumMeshes; i++) {
+  for (int i = 0; i < aiNode->mNumMeshes; i++)
+  {
     int aiMeshIndex = aiNode->mMeshes[i];
-    const struct aiMesh* aiMesh = aiScene->mMeshes[aiMeshIndex];
+    const struct aiMesh *aiMesh = aiScene->mMeshes[aiMeshIndex];
     nFaces += aiMesh->mNumFaces;
   }
   return nFaces;
 }
 
 - (int)findNumIndicesInMesh:(int)aiMeshIndex
-                    inScene:(const struct aiScene*)aiScene
+                    inScene:(const struct aiScene *)aiScene
 {
   int nIndices = 0;
-  const struct aiMesh* aiMesh = aiScene->mMeshes[aiMeshIndex];
-  for (int j = 0; j < aiMesh->mNumFaces; j++) {
-    const struct aiFace* aiFace = &aiMesh->mFaces[j];
+  const struct aiMesh *aiMesh = aiScene->mMeshes[aiMeshIndex];
+  for (int j = 0; j < aiMesh->mNumFaces; j++)
+  {
+    const struct aiFace *aiFace = &aiMesh->mFaces[j];
     nIndices += aiFace->mNumIndices;
   }
   return nIndices;
@@ -177,83 +187,91 @@ AssimpImporter ()
 
 #pragma mark - Make SCN Geometry sources
 
-- (SCNGeometrySource*)
-makeVertexGeometrySourceForNode:(const struct aiNode*)aiNode
-                        inScene:(const struct aiScene*)aiScene
+- (SCNGeometrySource *)
+makeVertexGeometrySourceForNode:(const struct aiNode *)aiNode
+                        inScene:(const struct aiScene *)aiScene
                   withNVertices:(int)nVertices
 {
   float scnVertices[nVertices * 3];
   int verticesCounter = 0;
-  for (int i = 0; i < aiNode->mNumMeshes; i++) {
+  for (int i = 0; i < aiNode->mNumMeshes; i++)
+  {
     int aiMeshIndex = aiNode->mMeshes[i];
-    const struct aiMesh* aiMesh = aiScene->mMeshes[aiMeshIndex];
+    const struct aiMesh *aiMesh = aiScene->mMeshes[aiMeshIndex];
     // create SCNGeometry source for aiMesh vertices, normals, texture
     // coordinates
-    for (int j = 0; j < aiMesh->mNumVertices; j++) {
-      const struct aiVector3D* aiVector3D = &aiMesh->mVertices[j];
+    for (int j = 0; j < aiMesh->mNumVertices; j++)
+    {
+      const struct aiVector3D *aiVector3D = &aiMesh->mVertices[j];
       scnVertices[verticesCounter++] = aiVector3D->x;
       scnVertices[verticesCounter++] = aiVector3D->y;
       scnVertices[verticesCounter++] = aiVector3D->z;
     }
   }
-  SCNGeometrySource* vertexSource = [SCNGeometrySource
-    geometrySourceWithData:[NSData dataWithBytes:scnVertices
-                                          length:nVertices * 3 * sizeof(float)]
-                  semantic:SCNGeometrySourceSemanticVertex
-               vectorCount:nVertices
-           floatComponents:YES
-       componentsPerVector:3
-         bytesPerComponent:sizeof(float)
-                dataOffset:0
-                dataStride:3 * sizeof(float)];
+  SCNGeometrySource *vertexSource = [SCNGeometrySource
+      geometrySourceWithData:[NSData dataWithBytes:scnVertices
+                                            length:nVertices * 3 * sizeof(float)]
+                    semantic:SCNGeometrySourceSemanticVertex
+                 vectorCount:nVertices
+             floatComponents:YES
+         componentsPerVector:3
+           bytesPerComponent:sizeof(float)
+                  dataOffset:0
+                  dataStride:3 * sizeof(float)];
   return vertexSource;
 }
 
-- (SCNGeometrySource*)
-makeNormalGeometrySourceForNode:(const struct aiNode*)aiNode
-                        inScene:(const struct aiScene*)aiScene
+- (SCNGeometrySource *)
+makeNormalGeometrySourceForNode:(const struct aiNode *)aiNode
+                        inScene:(const struct aiScene *)aiScene
                   withNVertices:(int)nVertices
 {
   float scnNormals[nVertices * 3];
   int verticesCounter = 0;
-  for (int i = 0; i < aiNode->mNumMeshes; i++) {
+  for (int i = 0; i < aiNode->mNumMeshes; i++)
+  {
     int aiMeshIndex = aiNode->mMeshes[i];
-    const struct aiMesh* aiMesh = aiScene->mMeshes[aiMeshIndex];
-    if (aiMesh->mNormals != NULL) {
-      for (int j = 0; j < aiMesh->mNumVertices; j++) {
-        const struct aiVector3D* aiVector3D = &aiMesh->mNormals[j];
+    const struct aiMesh *aiMesh = aiScene->mMeshes[aiMeshIndex];
+    if (aiMesh->mNormals != NULL)
+    {
+      for (int j = 0; j < aiMesh->mNumVertices; j++)
+      {
+        const struct aiVector3D *aiVector3D = &aiMesh->mNormals[j];
         scnNormals[verticesCounter++] = aiVector3D->x;
         scnNormals[verticesCounter++] = aiVector3D->y;
         scnNormals[verticesCounter++] = aiVector3D->z;
       }
     }
   }
-  SCNGeometrySource* normalSource = [SCNGeometrySource
-    geometrySourceWithData:[NSData dataWithBytes:scnNormals
-                                          length:nVertices * 3 * sizeof(float)]
-                  semantic:SCNGeometrySourceSemanticNormal
-               vectorCount:nVertices
-           floatComponents:YES
-       componentsPerVector:3
-         bytesPerComponent:sizeof(float)
-                dataOffset:0
-                dataStride:3 * sizeof(float)];
+  SCNGeometrySource *normalSource = [SCNGeometrySource
+      geometrySourceWithData:[NSData dataWithBytes:scnNormals
+                                            length:nVertices * 3 * sizeof(float)]
+                    semantic:SCNGeometrySourceSemanticNormal
+                 vectorCount:nVertices
+             floatComponents:YES
+         componentsPerVector:3
+           bytesPerComponent:sizeof(float)
+                  dataOffset:0
+                  dataStride:3 * sizeof(float)];
   return normalSource;
 }
 
-- (SCNGeometrySource*)
-makeTextureGeometrySourceForNode:(const struct aiNode*)aiNode
-                         inScene:(const struct aiScene*)aiScene
+- (SCNGeometrySource *)
+makeTextureGeometrySourceForNode:(const struct aiNode *)aiNode
+                         inScene:(const struct aiScene *)aiScene
                    withNVertices:(int)nVertices
 {
   float scnTextures[nVertices * 2];
   int verticesCounter = 0;
-  for (int i = 0; i < aiNode->mNumMeshes; i++) {
+  for (int i = 0; i < aiNode->mNumMeshes; i++)
+  {
     int aiMeshIndex = aiNode->mMeshes[i];
-    const struct aiMesh* aiMesh = aiScene->mMeshes[aiMeshIndex];
-    if (aiMesh->mTextureCoords[0] != NULL) {
+    const struct aiMesh *aiMesh = aiScene->mMeshes[aiMeshIndex];
+    if (aiMesh->mTextureCoords[0] != NULL)
+    {
       NSLog(@"  Getting texture coordinates");
-      for (int j = 0; j < aiMesh->mNumVertices; j++) {
+      for (int j = 0; j < aiMesh->mNumVertices; j++)
+      {
         float x = aiMesh->mTextureCoords[0][j].x;
         float y = aiMesh->mTextureCoords[0][j].y;
         scnTextures[verticesCounter++] = x;
@@ -261,83 +279,87 @@ makeTextureGeometrySourceForNode:(const struct aiNode*)aiNode
       }
     }
   }
-  SCNGeometrySource* textureSource = [SCNGeometrySource
-    geometrySourceWithData:[NSData dataWithBytes:scnTextures
-                                          length:nVertices * 2 * sizeof(float)]
-                  semantic:SCNGeometrySourceSemanticTexcoord
-               vectorCount:nVertices
-           floatComponents:YES
-       componentsPerVector:2
-         bytesPerComponent:sizeof(float)
-                dataOffset:0
-                dataStride:2 * sizeof(float)];
+  SCNGeometrySource *textureSource = [SCNGeometrySource
+      geometrySourceWithData:[NSData dataWithBytes:scnTextures
+                                            length:nVertices * 2 * sizeof(float)]
+                    semantic:SCNGeometrySourceSemanticTexcoord
+                 vectorCount:nVertices
+             floatComponents:YES
+         componentsPerVector:2
+           bytesPerComponent:sizeof(float)
+                  dataOffset:0
+                  dataStride:2 * sizeof(float)];
   return textureSource;
 }
 
-- (NSArray*)makeGeometrySourcesForNode:(const struct aiNode*)aiNode
-                               inScene:(const struct aiScene*)aiScene
-                          withVertices:(int)nVertices
+- (NSArray *)makeGeometrySourcesForNode:(const struct aiNode *)aiNode
+                                inScene:(const struct aiScene *)aiScene
+                           withVertices:(int)nVertices
 {
-  NSMutableArray* scnGeometrySources = [[NSMutableArray alloc] init];
+  NSMutableArray *scnGeometrySources = [[NSMutableArray alloc] init];
   [scnGeometrySources
-    addObject:[self makeVertexGeometrySourceForNode:aiNode
-                                            inScene:aiScene
-                                      withNVertices:nVertices]];
+      addObject:[self makeVertexGeometrySourceForNode:aiNode
+                                              inScene:aiScene
+                                        withNVertices:nVertices]];
   [scnGeometrySources
-    addObject:[self makeNormalGeometrySourceForNode:aiNode
-                                            inScene:aiScene
-                                      withNVertices:nVertices]];
+      addObject:[self makeNormalGeometrySourceForNode:aiNode
+                                              inScene:aiScene
+                                        withNVertices:nVertices]];
   [scnGeometrySources
-    addObject:[self makeTextureGeometrySourceForNode:aiNode
-                                             inScene:aiScene
-                                       withNVertices:nVertices]];
+      addObject:[self makeTextureGeometrySourceForNode:aiNode
+                                               inScene:aiScene
+                                         withNVertices:nVertices]];
   return scnGeometrySources;
 }
 
 #pragma mark - Make SCN Geometry elements
 
-- (SCNGeometryElement*)
+- (SCNGeometryElement *)
 makeIndicesGeometryElementForMeshIndex:(int)aiMeshIndex
-                                inNode:(const struct aiNode*)aiNode
-                               inScene:(const struct aiScene*)aiScene
+                                inNode:(const struct aiNode *)aiNode
+                               inScene:(const struct aiScene *)aiScene
                        withIndexOffset:(short)indexOffset
                                 nFaces:(int)nFaces
 {
   int indicesCounter = 0;
   int nIndices = [self findNumIndicesInMesh:aiMeshIndex inScene:aiScene];
   short scnIndices[nIndices];
-  const struct aiMesh* aiMesh = aiScene->mMeshes[aiMeshIndex];
-  for (int i = 0; i < aiMesh->mNumFaces; i++) {
-    const struct aiFace* aiFace = &aiMesh->mFaces[i];
-    for (int j = 0; j < aiFace->mNumIndices; j++) {
+  const struct aiMesh *aiMesh = aiScene->mMeshes[aiMeshIndex];
+  for (int i = 0; i < aiMesh->mNumFaces; i++)
+  {
+    const struct aiFace *aiFace = &aiMesh->mFaces[i];
+    for (int j = 0; j < aiFace->mNumIndices; j++)
+    {
       scnIndices[indicesCounter++] =
-        (short)indexOffset + (short)aiFace->mIndices[j];
+          (short)indexOffset + (short)aiFace->mIndices[j];
     }
   }
-  NSData* indicesData =
-    [NSData dataWithBytes:scnIndices length:sizeof(scnIndices)];
-  SCNGeometryElement* indices = [SCNGeometryElement
-    geometryElementWithData:indicesData
-              primitiveType:SCNGeometryPrimitiveTypeTriangles
-             primitiveCount:nFaces
-              bytesPerIndex:sizeof(short)];
+  NSData *indicesData =
+      [NSData dataWithBytes:scnIndices
+                     length:sizeof(scnIndices)];
+  SCNGeometryElement *indices = [SCNGeometryElement
+      geometryElementWithData:indicesData
+                primitiveType:SCNGeometryPrimitiveTypeTriangles
+               primitiveCount:nFaces
+                bytesPerIndex:sizeof(short)];
   return indices;
 }
 
-- (NSArray*)makeGeometryElementsforNode:(const struct aiNode*)aiNode
-                                inScene:(const struct aiScene*)aiScene
+- (NSArray *)makeGeometryElementsforNode:(const struct aiNode *)aiNode
+                                 inScene:(const struct aiScene *)aiScene
 {
-  NSMutableArray* scnGeometryElements = [[NSMutableArray alloc] init];
+  NSMutableArray *scnGeometryElements = [[NSMutableArray alloc] init];
   int indexOffset = 0;
-  for (int i = 0; i < aiNode->mNumMeshes; i++) {
+  for (int i = 0; i < aiNode->mNumMeshes; i++)
+  {
     int aiMeshIndex = aiNode->mMeshes[i];
-    const struct aiMesh* aiMesh = aiScene->mMeshes[aiMeshIndex];
-    SCNGeometryElement* indices =
-      [self makeIndicesGeometryElementForMeshIndex:aiMeshIndex
-                                            inNode:aiNode
-                                           inScene:aiScene
-                                   withIndexOffset:indexOffset
-                                            nFaces:aiMesh->mNumFaces];
+    const struct aiMesh *aiMesh = aiScene->mMeshes[aiMeshIndex];
+    SCNGeometryElement *indices =
+        [self makeIndicesGeometryElementForMeshIndex:aiMeshIndex
+                                              inNode:aiNode
+                                             inScene:aiScene
+                                     withIndexOffset:indexOffset
+                                              nFaces:aiMesh->mNumFaces];
     [scnGeometryElements addObject:indices];
     indexOffset += aiMesh->mNumVertices;
   }
@@ -347,54 +369,70 @@ makeIndicesGeometryElementForMeshIndex:(int)aiMeshIndex
 
 #pragma mark - Make Materials
 
-- (void)makeMaterialPropertyForMaterial:(const struct aiMaterial*)aiMaterial
+- (void)makeMaterialPropertyForMaterial:(const struct aiMaterial *)aiMaterial
                         withTextureType:(enum aiTextureType)aiTextureType
-                        withSCNMaterial:(SCNMaterial*)material
-                                 atPath:(NSString*)path
+                        withSCNMaterial:(SCNMaterial *)material
+                                 atPath:(NSString *)path
 {
   int nTextures = aiGetMaterialTextureCount(aiMaterial, aiTextureType);
-  if (nTextures > 0) {
+  if (nTextures > 0)
+  {
     NSLog(@" has %d textures", nTextures);
     struct aiString aiPath;
     aiGetMaterialTexture(aiMaterial, aiTextureType, 0, &aiPath, NULL, NULL,
                          NULL, NULL, NULL, NULL);
-    NSString* texFileName = [NSString stringWithUTF8String:&aiPath.data];
-    NSString* sceneDir =
-      [[path stringByDeletingLastPathComponent] stringByAppendingString:@"/"];
-    NSString* texPath = [sceneDir
-      stringByAppendingString:[NSString stringWithUTF8String:&aiPath.data]];
+    NSString *texFileName = [NSString stringWithUTF8String:&aiPath.data];
+    NSString *sceneDir =
+        [[path stringByDeletingLastPathComponent] stringByAppendingString:@"/"];
+    NSString *texPath = [sceneDir
+        stringByAppendingString:[NSString stringWithUTF8String:&aiPath.data]];
     NSLog(@"  tex path is %@", texPath);
 
-    NSString* channel = @".mappingChannel";
-    NSString* wrapS = @".wrapS";
-    NSString* wrapT = @".wrapS";
-    NSString* intensity = @".intensity";
-    NSString* minFilter = @".minificationFilter";
-    NSString* magFilter = @".magnificationFilter";
+    NSString *channel = @".mappingChannel";
+    NSString *wrapS = @".wrapS";
+    NSString *wrapT = @".wrapS";
+    NSString *intensity = @".intensity";
+    NSString *minFilter = @".minificationFilter";
+    NSString *magFilter = @".magnificationFilter";
 
-    NSString* keyPrefix = @"";
-    if (aiTextureType == aiTextureType_DIFFUSE) {
+    NSString *keyPrefix = @"";
+    if (aiTextureType == aiTextureType_DIFFUSE)
+    {
       material.diffuse.contents = texPath;
       keyPrefix = @"diffuse";
-    } else if (aiTextureType == aiTextureType_SPECULAR) {
+    }
+    else if (aiTextureType == aiTextureType_SPECULAR)
+    {
       material.specular.contents = texPath;
       keyPrefix = @"specular";
-    } else if (aiTextureType == aiTextureType_AMBIENT) {
+    }
+    else if (aiTextureType == aiTextureType_AMBIENT)
+    {
       material.specular.contents = texPath;
       keyPrefix = @"ambient";
-    } else if (aiTextureType == aiTextureType_REFLECTION) {
+    }
+    else if (aiTextureType == aiTextureType_REFLECTION)
+    {
       material.specular.contents = texPath;
       keyPrefix = @"reflective";
-    } else if (aiTextureType == aiTextureType_EMISSIVE) {
+    }
+    else if (aiTextureType == aiTextureType_EMISSIVE)
+    {
       material.specular.contents = texPath;
       keyPrefix = @"emissive";
-    } else if (aiTextureType == aiTextureType_OPACITY) {
+    }
+    else if (aiTextureType == aiTextureType_OPACITY)
+    {
       material.specular.contents = texPath;
       keyPrefix = @"transparent";
-    } else if (aiTextureType == aiTextureType_NORMALS) {
+    }
+    else if (aiTextureType == aiTextureType_NORMALS)
+    {
       material.specular.contents = texPath;
       keyPrefix = @"normal";
-    } else if (aiTextureType == aiTextureType_LIGHTMAP) {
+    }
+    else if (aiTextureType == aiTextureType_LIGHTMAP)
+    {
       material.specular.contents = texPath;
       keyPrefix = @"ambientOcclusion";
     }
@@ -415,42 +453,56 @@ makeIndicesGeometryElementForMeshIndex:(int)aiMeshIndex
                 forKey:minFilter];
     [material setValue:[NSNumber numberWithInt:SCNFilterModeLinear]
                 forKey:magFilter];
-  } else {
+  }
+  else
+  {
     NSLog(@" has color");
     struct aiColor4D color;
     color.r = 0.0f;
     color.g = 0.0f;
     color.b = 0.0f;
     int matColor = -100;
-    NSString* key = @"";
-    if (aiTextureType == aiTextureType_DIFFUSE) {
+    NSString *key = @"";
+    if (aiTextureType == aiTextureType_DIFFUSE)
+    {
       matColor =
-        aiGetMaterialColor(aiMaterial, AI_MATKEY_COLOR_DIFFUSE, &color);
+          aiGetMaterialColor(aiMaterial, AI_MATKEY_COLOR_DIFFUSE, &color);
       key = @"diffuse.contents";
-    } else if (aiTextureType == aiTextureType_SPECULAR) {
+    }
+    else if (aiTextureType == aiTextureType_SPECULAR)
+    {
       matColor =
-        aiGetMaterialColor(aiMaterial, AI_MATKEY_COLOR_SPECULAR, &color);
+          aiGetMaterialColor(aiMaterial, AI_MATKEY_COLOR_SPECULAR, &color);
       key = @"specular.contents";
-    } else if (aiTextureType == aiTextureType_AMBIENT) {
+    }
+    else if (aiTextureType == aiTextureType_AMBIENT)
+    {
       matColor =
-        aiGetMaterialColor(aiMaterial, AI_MATKEY_COLOR_AMBIENT, &color);
+          aiGetMaterialColor(aiMaterial, AI_MATKEY_COLOR_AMBIENT, &color);
       key = @"ambient.contents";
-    } else if (aiTextureType == aiTextureType_REFLECTION) {
+    }
+    else if (aiTextureType == aiTextureType_REFLECTION)
+    {
       matColor =
-        aiGetMaterialColor(aiMaterial, AI_MATKEY_COLOR_REFLECTIVE, &color);
+          aiGetMaterialColor(aiMaterial, AI_MATKEY_COLOR_REFLECTIVE, &color);
       key = @"reflective.contents";
-    } else if (aiTextureType == aiTextureType_EMISSIVE) {
+    }
+    else if (aiTextureType == aiTextureType_EMISSIVE)
+    {
       matColor =
-        aiGetMaterialColor(aiMaterial, AI_MATKEY_COLOR_EMISSIVE, &color);
+          aiGetMaterialColor(aiMaterial, AI_MATKEY_COLOR_EMISSIVE, &color);
       key = @"emissive.contents";
-    } else if (aiTextureType == aiTextureType_OPACITY) {
+    }
+    else if (aiTextureType == aiTextureType_OPACITY)
+    {
       matColor =
-        aiGetMaterialColor(aiMaterial, AI_MATKEY_COLOR_TRANSPARENT, &color);
+          aiGetMaterialColor(aiMaterial, AI_MATKEY_COLOR_TRANSPARENT, &color);
       key = @"transparent.contents";
     }
-    if (AI_SUCCESS == matColor) {
+    if (AI_SUCCESS == matColor)
+    {
       CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();
-      CGFloat components[4] = { color.r, color.g, color.b, color.a };
+      CGFloat components[4] = {color.r, color.g, color.b, color.a};
       CGColorRef color = CGColorCreate(space, components);
       [material setValue:(__bridge id _Nullable)color forKey:key];
       CGColorSpaceRelease(space);
@@ -459,9 +511,9 @@ makeIndicesGeometryElementForMeshIndex:(int)aiMeshIndex
   }
 }
 
-- (void)applyMultiplyPropertyForMaterial:(const struct aiMaterial*)aiMaterial
-                         withSCNMaterial:(SCNMaterial*)material
-                                  atPath:(NSString*)path
+- (void)applyMultiplyPropertyForMaterial:(const struct aiMaterial *)aiMaterial
+                         withSCNMaterial:(SCNMaterial *)material
+                                  atPath:(NSString *)path
 {
   struct aiColor4D color;
   color.r = 0.0f;
@@ -469,12 +521,14 @@ makeIndicesGeometryElementForMeshIndex:(int)aiMeshIndex
   color.b = 0.0f;
   int matColor = -100;
   matColor =
-    aiGetMaterialColor(aiMaterial, AI_MATKEY_COLOR_TRANSPARENT, &color);
-  NSString* key = @"multiply.contents";
-  if (AI_SUCCESS == matColor) {
-    if (color.r != 0 && color.g != 0 && color.b != 0) {
+      aiGetMaterialColor(aiMaterial, AI_MATKEY_COLOR_TRANSPARENT, &color);
+  NSString *key = @"multiply.contents";
+  if (AI_SUCCESS == matColor)
+  {
+    if (color.r != 0 && color.g != 0 && color.b != 0)
+    {
       CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();
-      CGFloat components[4] = { color.r, color.g, color.b, color.a };
+      CGFloat components[4] = {color.r, color.g, color.b, color.a};
       CGColorRef color = CGColorCreate(space, components);
       material.multiply.contents = (__bridge id _Nullable)(color);
       CGColorSpaceRelease(space);
@@ -483,20 +537,21 @@ makeIndicesGeometryElementForMeshIndex:(int)aiMeshIndex
   }
 }
 
-- (NSMutableArray*)makeMaterialsForNode:(const struct aiNode*)aiNode
-                                inScene:(const struct aiScene*)aiScene
-                                 atPath:(NSString*)path
+- (NSMutableArray *)makeMaterialsForNode:(const struct aiNode *)aiNode
+                                 inScene:(const struct aiScene *)aiScene
+                                  atPath:(NSString *)path
 {
-  NSMutableArray* scnMaterials = [[NSMutableArray alloc] init];
-  for (int i = 0; i < aiNode->mNumMeshes; i++) {
+  NSMutableArray *scnMaterials = [[NSMutableArray alloc] init];
+  for (int i = 0; i < aiNode->mNumMeshes; i++)
+  {
     int aiMeshIndex = aiNode->mMeshes[i];
-    const struct aiMesh* aiMesh = aiScene->mMeshes[aiMeshIndex];
-    const struct aiMaterial* aiMaterial =
-      aiScene->mMaterials[aiMesh->mMaterialIndex];
+    const struct aiMesh *aiMesh = aiScene->mMeshes[aiMeshIndex];
+    const struct aiMaterial *aiMaterial =
+        aiScene->mMaterials[aiMesh->mMaterialIndex];
     struct aiString name;
     aiGetMaterialString(aiMaterial, AI_MATKEY_NAME, &name);
     NSLog(@" Material name is %@", [NSString stringWithUTF8String:&name.data]);
-    SCNMaterial* material = [SCNMaterial material];
+    SCNMaterial *material = [SCNMaterial material];
     NSLog(@"+++ Loading diffuse");
     [self makeMaterialPropertyForMaterial:aiMaterial
                           withTextureType:aiTextureType_DIFFUSE
@@ -538,13 +593,16 @@ makeIndicesGeometryElementForMeshIndex:(int)aiMeshIndex
                                     atPath:path];
     NSLog(@"+++ Loading blend mode");
     int blendMode = 0;
-    int* max;
+    int *max;
     aiGetMaterialIntegerArray(aiMaterial, AI_MATKEY_BLEND_FUNC,
-                              (int*)&blendMode, max);
-    if (blendMode == aiBlendMode_Default) {
+                              (int *)&blendMode, max);
+    if (blendMode == aiBlendMode_Default)
+    {
       NSLog(@" Using alpha blend mode");
       material.blendMode = SCNBlendModeAlpha;
-    } else if (blendMode == aiBlendMode_Additive) {
+    }
+    else if (blendMode == aiBlendMode_Additive)
+    {
       NSLog(@" Using add blend mode");
       material.blendMode = SCNBlendModeAdd;
     }
@@ -558,7 +616,7 @@ makeIndicesGeometryElementForMeshIndex:(int)aiMeshIndex
     NSLog(@"+++ Loading shininess");
     float shininess = 0.0;
     aiGetMaterialIntegerArray(aiMaterial, AI_MATKEY_BLEND_FUNC,
-                              (float*)&shininess, max);
+                              (float *)&shininess, max);
     NSLog(@"   shininess: %f", shininess);
     material.shininess = shininess;
     NSLog(@"+++ Loading shading model");
@@ -574,24 +632,29 @@ makeIndicesGeometryElementForMeshIndex:(int)aiMeshIndex
   return scnMaterials;
 }
 
-- (SCNGeometry*)makeSCNGeometryFromAssimpNode:(const struct aiNode*)aiNode
-                                      inScene:(const struct aiScene*)aiScene
-                                 withVertices:(int)nVertices
-                                       atPath:(NSString*)path
+- (SCNGeometry *)makeSCNGeometryFromAssimpNode:(const struct aiNode *)aiNode
+                                       inScene:(const struct aiScene *)aiScene
+                                  withVertices:(int)nVertices
+                                        atPath:(NSString *)path
 {
   // make SCNGeometry with sources, elements and materials
-  NSArray* scnGeometrySources = [self makeGeometrySourcesForNode:aiNode
+  NSArray *scnGeometrySources = [self makeGeometrySourcesForNode:aiNode
                                                          inScene:aiScene
                                                     withVertices:nVertices];
-  if (scnGeometrySources.count > 0) {
-    NSArray* scnGeometryElements =
-      [self makeGeometryElementsforNode:aiNode inScene:aiScene];
-    SCNGeometry* scnGeometry =
-      [SCNGeometry geometryWithSources:scnGeometrySources
-                              elements:scnGeometryElements];
-    NSArray* scnMaterials =
-      [self makeMaterialsForNode:aiNode inScene:aiScene atPath:path];
-    if (scnMaterials.count > 0) {
+  if (scnGeometrySources.count > 0)
+  {
+    NSArray *scnGeometryElements =
+        [self makeGeometryElementsforNode:aiNode
+                                  inScene:aiScene];
+    SCNGeometry *scnGeometry =
+        [SCNGeometry geometryWithSources:scnGeometrySources
+                                elements:scnGeometryElements];
+    NSArray *scnMaterials =
+        [self makeMaterialsForNode:aiNode
+                           inScene:aiScene
+                            atPath:path];
+    if (scnMaterials.count > 0)
+    {
       scnGeometry.materials = scnMaterials;
       scnGeometry.firstMaterial = [scnMaterials objectAtIndex:0];
     }
@@ -602,16 +665,17 @@ makeIndicesGeometryElementForMeshIndex:(int)aiMeshIndex
 
 #pragma mark - Make Lights
 
-- (SCNLight*)makeSCNLightTypeDirectionalForAssimpLight:
-  (const struct aiLight*)aiLight
+- (SCNLight *)makeSCNLightTypeDirectionalForAssimpLight:
+    (const struct aiLight *)aiLight
 {
-  SCNLight* light = [SCNLight light];
+  SCNLight *light = [SCNLight light];
   light.type = SCNLightTypeDirectional;
   const struct aiColor3D aiColor = aiLight->mColorSpecular;
-  if (aiColor.r != 0 && aiColor.g != 0 && aiColor.b != 0) {
+  if (aiColor.r != 0 && aiColor.g != 0 && aiColor.b != 0)
+  {
     NSLog(@" Setting color: %f %f %f", aiColor.r, aiColor.g, aiColor.b);
     CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();
-    CGFloat components[4] = { aiColor.r, aiColor.g, aiColor.b, 1.0 };
+    CGFloat components[4] = {aiColor.r, aiColor.g, aiColor.b, 1.0};
     CGColorRef cgGolor = CGColorCreate(space, components);
     light.color = (__bridge id _Nullable)(cgGolor);
     CGColorSpaceRelease(space);
@@ -620,45 +684,53 @@ makeIndicesGeometryElementForMeshIndex:(int)aiMeshIndex
   return light;
 }
 
-- (SCNLight*)makeSCNLightTypePointForAssimpLight:(const struct aiLight*)aiLight
+- (SCNLight *)makeSCNLightTypePointForAssimpLight:(const struct aiLight *)aiLight
 {
-  SCNLight* light = [SCNLight light];
+  SCNLight *light = [SCNLight light];
   light.type = SCNLightTypeOmni;
   const struct aiColor3D aiColor = aiLight->mColorSpecular;
-  if (aiColor.r != 0 && aiColor.g != 0 && aiColor.b != 0) {
+  if (aiColor.r != 0 && aiColor.g != 0 && aiColor.b != 0)
+  {
     NSLog(@" Setting color: %f %f %f", aiColor.r, aiColor.g, aiColor.b);
     CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();
-    CGFloat components[4] = { aiColor.r, aiColor.g, aiColor.b, 1.0 };
+    CGFloat components[4] = {aiColor.r, aiColor.g, aiColor.b, 1.0};
     CGColorRef cgGolor = CGColorCreate(space, components);
     light.color = (__bridge id _Nullable)(cgGolor);
     CGColorSpaceRelease(space);
     CGColorRelease(cgGolor);
   }
-  if (aiLight->mAttenuationQuadratic != 0) {
+  if (aiLight->mAttenuationQuadratic != 0)
+  {
     light.attenuationFalloffExponent = 2.0;
-  } else if (aiLight->mAttenuationLinear != 0) {
+  }
+  else if (aiLight->mAttenuationLinear != 0)
+  {
     light.attenuationFalloffExponent = 1.0;
   }
   return light;
 }
 
-- (SCNLight*)makeSCNLightTypeSpotForAssimpLight:(const struct aiLight*)aiLight
+- (SCNLight *)makeSCNLightTypeSpotForAssimpLight:(const struct aiLight *)aiLight
 {
-  SCNLight* light = [SCNLight light];
+  SCNLight *light = [SCNLight light];
   light.type = SCNLightTypeOmni;
   const struct aiColor3D aiColor = aiLight->mColorSpecular;
-  if (aiColor.r != 0 && aiColor.g != 0 && aiColor.b != 0) {
+  if (aiColor.r != 0 && aiColor.g != 0 && aiColor.b != 0)
+  {
     NSLog(@" Setting color: %f %f %f", aiColor.r, aiColor.g, aiColor.b);
     CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();
-    CGFloat components[4] = { aiColor.r, aiColor.g, aiColor.b, 1.0 };
+    CGFloat components[4] = {aiColor.r, aiColor.g, aiColor.b, 1.0};
     CGColorRef cgGolor = CGColorCreate(space, components);
     light.color = (__bridge id _Nullable)(cgGolor);
     CGColorSpaceRelease(space);
     CGColorRelease(cgGolor);
   }
-  if (aiLight->mAttenuationQuadratic != 0) {
+  if (aiLight->mAttenuationQuadratic != 0)
+  {
     light.attenuationFalloffExponent = 2.0;
-  } else if (aiLight->mAttenuationLinear != 0) {
+  }
+  else if (aiLight->mAttenuationLinear != 0)
+  {
     light.attenuationFalloffExponent = 1.0;
   }
   light.attenuationStartDistance = 0;
@@ -668,17 +740,19 @@ makeIndicesGeometryElementForMeshIndex:(int)aiMeshIndex
   return light;
 }
 
-- (SCNLight*)makeSCNLightFromAssimpNode:(const struct aiNode*)aiNode
-                                inScene:(const struct aiScene*)aiScene
+- (SCNLight *)makeSCNLightFromAssimpNode:(const struct aiNode *)aiNode
+                                 inScene:(const struct aiScene *)aiScene
 {
   const struct aiString aiNodeName = aiNode->mName;
-  NSString* nodeName = [NSString stringWithUTF8String:&aiNodeName.data];
-  for (int i = 0; i < aiScene->mNumLights; i++) {
-    const struct aiLight* aiLight = aiScene->mLights[i];
+  NSString *nodeName = [NSString stringWithUTF8String:&aiNodeName.data];
+  for (int i = 0; i < aiScene->mNumLights; i++)
+  {
+    const struct aiLight *aiLight = aiScene->mLights[i];
     const struct aiString aiLightNodeName = aiLight->mName;
-    NSString* lightNodeName =
-      [NSString stringWithUTF8String:&aiLightNodeName.data];
-    if ([nodeName isEqualToString:lightNodeName]) {
+    NSString *lightNodeName =
+        [NSString stringWithUTF8String:&aiLightNodeName.data];
+    if ([nodeName isEqualToString:lightNodeName])
+    {
       NSLog(@"### Creating light for node %@", nodeName);
       NSLog(@"    ambient     %f %f %f ", aiLight->mColorAmbient.r,
             aiLight->mColorAmbient.g, aiLight->mColorAmbient.b);
@@ -693,13 +767,18 @@ makeIndicesGeometryElementForMeshIndex:(int)aiMeshIndex
       NSLog(@"    att quad    %f", aiLight->mAttenuationQuadratic);
       NSLog(@"    position    %f %f %f", aiLight->mPosition.x,
             aiLight->mPosition.y, aiLight->mPosition.z);
-      if (aiLight->mType == aiLightSource_DIRECTIONAL) {
+      if (aiLight->mType == aiLightSource_DIRECTIONAL)
+      {
         NSLog(@"    type        Directional");
         return [self makeSCNLightTypeDirectionalForAssimpLight:aiLight];
-      } else if (aiLight->mType == aiLightSource_POINT) {
+      }
+      else if (aiLight->mType == aiLightSource_POINT)
+      {
         NSLog(@"    type        Omni");
         return [self makeSCNLightTypePointForAssimpLight:aiLight];
-      } else if (aiLight->mType == aiLightSource_SPOT) {
+      }
+      else if (aiLight->mType == aiLightSource_SPOT)
+      {
         NSLog(@"    type        Spot");
         return [self makeSCNLightTypeSpotForAssimpLight:aiLight];
       }
@@ -709,18 +788,20 @@ makeIndicesGeometryElementForMeshIndex:(int)aiMeshIndex
 }
 
 #pragma mark - Make Cameras
-- (SCNCamera*)makeSCNCameraFromAssimpNode:(const struct aiNode*)aiNode
-                                  inScene:(const struct aiScene*)aiScene
+- (SCNCamera *)makeSCNCameraFromAssimpNode:(const struct aiNode *)aiNode
+                                   inScene:(const struct aiScene *)aiScene
 {
   const struct aiString aiNodeName = aiNode->mName;
-  NSString* nodeName = [NSString stringWithUTF8String:&aiNodeName.data];
-  for (int i = 0; i < aiScene->mNumCameras; i++) {
-    const struct aiCamera* aiCamera = aiScene->mCameras[i];
+  NSString *nodeName = [NSString stringWithUTF8String:&aiNodeName.data];
+  for (int i = 0; i < aiScene->mNumCameras; i++)
+  {
+    const struct aiCamera *aiCamera = aiScene->mCameras[i];
     const struct aiString aiCameraName = aiCamera->mName;
-    NSString* cameraNodeName =
-      [NSString stringWithUTF8String:&aiCameraName.data];
-    if ([nodeName isEqualToString:cameraNodeName]) {
-      SCNCamera* camera = [SCNCamera camera];
+    NSString *cameraNodeName =
+        [NSString stringWithUTF8String:&aiCameraName.data];
+    if ([nodeName isEqualToString:cameraNodeName])
+    {
+      SCNCamera *camera = [SCNCamera camera];
       camera.xFov = aiCamera->mHorizontalFOV;
       camera.zNear = aiCamera->mClipPlaneNear;
       camera.zFar = aiCamera->mClipPlaneFar;
@@ -732,28 +813,31 @@ makeIndicesGeometryElementForMeshIndex:(int)aiMeshIndex
 
 #pragma mark - Make Skinner
 
-- (int)findNumBonesInNode:(const struct aiNode*)aiNode
-                  inScene:(const struct aiScene*)aiScene
+- (int)findNumBonesInNode:(const struct aiNode *)aiNode
+                  inScene:(const struct aiScene *)aiScene
 {
   int nBones = 0;
-  for (int i = 0; i < aiNode->mNumMeshes; i++) {
+  for (int i = 0; i < aiNode->mNumMeshes; i++)
+  {
     int aiMeshIndex = aiNode->mMeshes[i];
-    const struct aiMesh* aiMesh = aiScene->mMeshes[aiMeshIndex];
+    const struct aiMesh *aiMesh = aiScene->mMeshes[aiMeshIndex];
     nBones += aiMesh->mNumBones;
   }
   return nBones;
 }
 
-- (NSArray*)getBoneNamesForAssimpNode:(const struct aiNode*)aiNode
-                              inScene:(const struct aiScene*)aiScene
+- (NSArray *)getBoneNamesForAssimpNode:(const struct aiNode *)aiNode
+                               inScene:(const struct aiScene *)aiScene
 {
-  NSMutableArray* boneNames = [[NSMutableArray alloc] init];
+  NSMutableArray *boneNames = [[NSMutableArray alloc] init];
 
-  for (int i = 0; i < aiNode->mNumMeshes; i++) {
+  for (int i = 0; i < aiNode->mNumMeshes; i++)
+  {
     int aiMeshIndex = aiNode->mMeshes[i];
-    const struct aiMesh* aiMesh = aiScene->mMeshes[aiMeshIndex];
-    for (int j = 0; j < aiMesh->mNumBones; j++) {
-      const struct aiBone* aiBone = aiMesh->mBones[j];
+    const struct aiMesh *aiMesh = aiScene->mMeshes[aiMeshIndex];
+    for (int j = 0; j < aiMesh->mNumBones; j++)
+    {
+      const struct aiBone *aiBone = aiMesh->mBones[j];
       const struct aiString name = aiBone->mName;
       [boneNames addObject:[NSString stringWithUTF8String:&name.data]];
     }
@@ -762,25 +846,28 @@ makeIndicesGeometryElementForMeshIndex:(int)aiMeshIndex
   return boneNames;
 }
 
-- (NSDictionary*)getBoneTransformsForAssimpNode:(const struct aiNode*)aiNode
-                                        inScene:(const struct aiScene*)aiScene
+- (NSDictionary *)getBoneTransformsForAssimpNode:(const struct aiNode *)aiNode
+                                         inScene:(const struct aiScene *)aiScene
 {
-  NSMutableDictionary* boneTransforms = [[NSMutableDictionary alloc] init];
+  NSMutableDictionary *boneTransforms = [[NSMutableDictionary alloc] init];
 
-  for (int i = 0; i < aiNode->mNumMeshes; i++) {
+  for (int i = 0; i < aiNode->mNumMeshes; i++)
+  {
     int aiMeshIndex = aiNode->mMeshes[i];
-    const struct aiMesh* aiMesh = aiScene->mMeshes[aiMeshIndex];
-    for (int j = 0; j < aiMesh->mNumBones; j++) {
-      const struct aiBone* aiBone = aiMesh->mBones[j];
+    const struct aiMesh *aiMesh = aiScene->mMeshes[aiMeshIndex];
+    for (int j = 0; j < aiMesh->mNumBones; j++)
+    {
+      const struct aiBone *aiBone = aiMesh->mBones[j];
       const struct aiString name = aiBone->mName;
-      NSString* key = [NSString stringWithUTF8String:&name.data];
-      if ([boneTransforms valueForKey:key] == nil) {
+      NSString *key = [NSString stringWithUTF8String:&name.data];
+      if ([boneTransforms valueForKey:key] == nil)
+      {
         const struct aiMatrix4x4 aiNodeMatrix = aiBone->mOffsetMatrix;
         GLKMatrix4 glkBoneMatrix = GLKMatrix4Make(
-          aiNodeMatrix.a1, aiNodeMatrix.b1, aiNodeMatrix.c1, aiNodeMatrix.d1,
-          aiNodeMatrix.a2, aiNodeMatrix.b2, aiNodeMatrix.c2, aiNodeMatrix.d2,
-          aiNodeMatrix.a3, aiNodeMatrix.b3, aiNodeMatrix.c3, aiNodeMatrix.d3,
-          aiNodeMatrix.a4, aiNodeMatrix.b4, aiNodeMatrix.c4, aiNodeMatrix.d4);
+            aiNodeMatrix.a1, aiNodeMatrix.b1, aiNodeMatrix.c1, aiNodeMatrix.d1,
+            aiNodeMatrix.a2, aiNodeMatrix.b2, aiNodeMatrix.c2, aiNodeMatrix.d2,
+            aiNodeMatrix.a3, aiNodeMatrix.b3, aiNodeMatrix.c3, aiNodeMatrix.d3,
+            aiNodeMatrix.a4, aiNodeMatrix.b4, aiNodeMatrix.c4, aiNodeMatrix.d4);
 
         SCNMatrix4 scnMatrix = SCNMatrix4FromGLKMatrix4(glkBoneMatrix);
         [boneTransforms setValue:[NSValue valueWithSCNMatrix4:scnMatrix]
@@ -792,99 +879,117 @@ makeIndicesGeometryElementForMeshIndex:(int)aiMeshIndex
   return boneTransforms;
 }
 
-- (NSArray*)getTransformsForBones:(NSArray*)boneNames
-                   fromTransforms:(NSDictionary*)boneTransforms
+- (NSArray *)getTransformsForBones:(NSArray *)boneNames
+                    fromTransforms:(NSDictionary *)boneTransforms
 {
-  NSMutableArray* transforms = [[NSMutableArray alloc] init];
-  for (NSString* boneName in boneNames) {
+  NSMutableArray *transforms = [[NSMutableArray alloc] init];
+  for (NSString *boneName in boneNames)
+  {
     [transforms addObject:[boneTransforms valueForKey:boneName]];
   }
   return transforms;
 }
 
-- (NSArray*)findBoneNodesInScene:(SCNScene*)scene forBones:(NSArray*)boneNames
+- (NSArray *)findBoneNodesInScene:(SCNScene *)scene forBones:(NSArray *)boneNames
 {
-  NSMutableArray* boneNodes = [[NSMutableArray alloc] init];
-  for (NSString* boneName in boneNames) {
-    SCNNode* boneNode =
-      [scene.rootNode childNodeWithName:boneName recursively:YES];
+  NSMutableArray *boneNodes = [[NSMutableArray alloc] init];
+  for (NSString *boneName in boneNames)
+  {
+    SCNNode *boneNode =
+        [scene.rootNode childNodeWithName:boneName
+                              recursively:YES];
     [boneNodes addObject:boneNode];
   }
   return boneNodes;
 }
 
-- (SCNNode*)findSkeletonNodeFromBoneNodes:(NSArray*)boneNodes
+- (SCNNode *)findSkeletonNodeFromBoneNodes:(NSArray *)boneNodes
 {
-  NSMutableDictionary* nodeDepths = [[NSMutableDictionary alloc] init];
+  NSMutableDictionary *nodeDepths = [[NSMutableDictionary alloc] init];
   int minDepth = -1;
-  for (SCNNode* boneNode in boneNodes) {
+  for (SCNNode *boneNode in boneNodes)
+  {
     int depth = [self findDepthOfNodeFromRoot:boneNode];
     NSLog(@" bone with depth is (min depth): %@ -> %d ( %d )", boneNode.name,
           depth, minDepth);
-    if (minDepth == -1 || (depth <= minDepth)) {
+    if (minDepth == -1 || (depth <= minDepth))
+    {
       minDepth = depth;
-      NSString* key = [NSNumber numberWithInt:minDepth].stringValue;
-      NSMutableArray* minDepthNodes = [nodeDepths valueForKey:key];
-      if (minDepthNodes == nil) {
+      NSString *key = [NSNumber numberWithInt:minDepth].stringValue;
+      NSMutableArray *minDepthNodes = [nodeDepths valueForKey:key];
+      if (minDepthNodes == nil)
+      {
         minDepthNodes = [[NSMutableArray alloc] init];
         [nodeDepths setValue:minDepthNodes forKey:key];
       }
       [minDepthNodes addObject:boneNode];
     }
   }
-  NSString* minDepthKey = [NSNumber numberWithInt:minDepth].stringValue;
-  NSArray* minDepthNodes = [nodeDepths valueForKey:minDepthKey];
+  NSString *minDepthKey = [NSNumber numberWithInt:minDepth].stringValue;
+  NSArray *minDepthNodes = [nodeDepths valueForKey:minDepthKey];
   NSLog(@" min depth nodes are: %@", minDepthNodes);
-  SCNNode* skeletonRootNode = [minDepthNodes objectAtIndex:0];
-  if (minDepthNodes.count > 1) {
+  SCNNode *skeletonRootNode = [minDepthNodes objectAtIndex:0];
+  if (minDepthNodes.count > 1)
+  {
     return skeletonRootNode.parentNode;
-  } else {
+  }
+  else
+  {
     return skeletonRootNode;
   }
 }
 
-- (int)findDepthOfNodeFromRoot:(SCNNode*)node
+- (int)findDepthOfNodeFromRoot:(SCNNode *)node
 {
   int depth = 0;
-  SCNNode* pNode = node;
-  while (pNode.parentNode) {
+  SCNNode *pNode = node;
+  while (pNode.parentNode)
+  {
     depth += 1;
     pNode = pNode.parentNode;
   }
   return depth;
 }
 
-- (int)findMaxWeightsForNode:(const struct aiNode*)aiNode
-                     inScene:(const struct aiScene*)aiScene
+- (int)findMaxWeightsForNode:(const struct aiNode *)aiNode
+                     inScene:(const struct aiScene *)aiScene
 {
   int maxWeights = 0;
 
-  for (int i = 0; i < aiNode->mNumMeshes; i++) {
+  for (int i = 0; i < aiNode->mNumMeshes; i++)
+  {
     int aiMeshIndex = aiNode->mMeshes[i];
-    const struct aiMesh* aiMesh = aiScene->mMeshes[aiMeshIndex];
-    NSMutableDictionary* meshWeights = [[NSMutableDictionary alloc] init];
-    for (int j = 0; j < aiMesh->mNumBones; j++) {
-      const struct aiBone* aiBone = aiMesh->mBones[j];
-      for (int k = 0; k < aiBone->mNumWeights; k++) {
-        const struct aiVertexWeight* aiVertexWeight = &aiBone->mWeights[k];
-        NSNumber* vertex = [NSNumber numberWithInt:aiVertexWeight->mVertexId];
-        if ([meshWeights valueForKey:vertex.stringValue] == nil) {
+    const struct aiMesh *aiMesh = aiScene->mMeshes[aiMeshIndex];
+    NSMutableDictionary *meshWeights = [[NSMutableDictionary alloc] init];
+    for (int j = 0; j < aiMesh->mNumBones; j++)
+    {
+      const struct aiBone *aiBone = aiMesh->mBones[j];
+      for (int k = 0; k < aiBone->mNumWeights; k++)
+      {
+        const struct aiVertexWeight *aiVertexWeight = &aiBone->mWeights[k];
+        NSNumber *vertex = [NSNumber numberWithInt:aiVertexWeight->mVertexId];
+        if ([meshWeights valueForKey:vertex.stringValue] == nil)
+        {
           [meshWeights setValue:[NSNumber numberWithInt:1]
                          forKey:vertex.stringValue];
-        } else {
-          NSNumber* weightCounts = [meshWeights valueForKey:vertex.stringValue];
+        }
+        else
+        {
+          NSNumber *weightCounts = [meshWeights valueForKey:vertex.stringValue];
           [meshWeights
-            setValue:[NSNumber numberWithInt:(weightCounts.intValue + 1)]
-              forKey:vertex.stringValue];
+              setValue:[NSNumber numberWithInt:(weightCounts.intValue + 1)]
+                forKey:vertex.stringValue];
         }
       }
     }
 
     // Find the vertex with most weights which is our max weights
-    for (int j = 0; j < aiMesh->mNumVertices; j++) {
-      NSNumber* vertex = [NSNumber numberWithInt:j];
-      NSNumber* weightsCount = [meshWeights valueForKey:vertex.stringValue];
-      if (weightsCount.intValue > maxWeights) {
+    for (int j = 0; j < aiMesh->mNumVertices; j++)
+    {
+      NSNumber *vertex = [NSNumber numberWithInt:j];
+      NSNumber *weightsCount = [meshWeights valueForKey:vertex.stringValue];
+      if (weightsCount.intValue > maxWeights)
+      {
         maxWeights = weightsCount.intValue;
       }
     }
@@ -893,47 +998,56 @@ makeIndicesGeometryElementForMeshIndex:(int)aiMeshIndex
   return maxWeights;
 }
 
-- (SCNGeometrySource*)
-makeBoneWeightsGeometrySourceAtNode:(const struct aiNode*)aiNode
-                            inScene:(const struct aiScene*)aiScene
+- (SCNGeometrySource *)
+makeBoneWeightsGeometrySourceAtNode:(const struct aiNode *)aiNode
+                            inScene:(const struct aiScene *)aiScene
                        withVertices:(int)nVertices
                          maxWeights:(int)maxWeights
 {
   float nodeGeometryWeights[nVertices * maxWeights];
   int weightCounter = 0;
 
-  for (int i = 0; i < aiNode->mNumMeshes; i++) {
+  for (int i = 0; i < aiNode->mNumMeshes; i++)
+  {
     int aiMeshIndex = aiNode->mMeshes[i];
-    const struct aiMesh* aiMesh = aiScene->mMeshes[aiMeshIndex];
-    NSMutableDictionary* meshWeights = [[NSMutableDictionary alloc] init];
-    for (int j = 0; j < aiMesh->mNumBones; j++) {
-      const struct aiBone* aiBone = aiMesh->mBones[j];
-      for (int k = 0; k < aiBone->mNumWeights; k++) {
-        const struct aiVertexWeight* aiVertexWeight = &aiBone->mWeights[k];
-        NSNumber* vertex = [NSNumber numberWithInt:aiVertexWeight->mVertexId];
-        NSNumber* weight = [NSNumber numberWithFloat:aiVertexWeight->mWeight];
-        if ([meshWeights valueForKey:vertex.stringValue] == nil) {
-          NSMutableArray* weights = [[NSMutableArray alloc] init];
+    const struct aiMesh *aiMesh = aiScene->mMeshes[aiMeshIndex];
+    NSMutableDictionary *meshWeights = [[NSMutableDictionary alloc] init];
+    for (int j = 0; j < aiMesh->mNumBones; j++)
+    {
+      const struct aiBone *aiBone = aiMesh->mBones[j];
+      for (int k = 0; k < aiBone->mNumWeights; k++)
+      {
+        const struct aiVertexWeight *aiVertexWeight = &aiBone->mWeights[k];
+        NSNumber *vertex = [NSNumber numberWithInt:aiVertexWeight->mVertexId];
+        NSNumber *weight = [NSNumber numberWithFloat:aiVertexWeight->mWeight];
+        if ([meshWeights valueForKey:vertex.stringValue] == nil)
+        {
+          NSMutableArray *weights = [[NSMutableArray alloc] init];
           [weights addObject:weight];
           [meshWeights setValue:weights forKey:vertex.stringValue];
-        } else {
-          NSMutableArray* weights =
-            [meshWeights valueForKey:vertex.stringValue];
+        }
+        else
+        {
+          NSMutableArray *weights =
+              [meshWeights valueForKey:vertex.stringValue];
           [weights addObject:weight];
         }
       }
     }
 
     // Add weights to the weights array for the entire node geometry
-    for (int j = 0; j < aiMesh->mNumVertices; j++) {
-      NSNumber* vertex = [NSNumber numberWithInt:j];
-      NSMutableArray* weights = [meshWeights valueForKey:vertex.stringValue];
+    for (int j = 0; j < aiMesh->mNumVertices; j++)
+    {
+      NSNumber *vertex = [NSNumber numberWithInt:j];
+      NSMutableArray *weights = [meshWeights valueForKey:vertex.stringValue];
       int zeroWeights = maxWeights - weights.count;
-      for (NSNumber* weight in weights) {
+      for (NSNumber *weight in weights)
+      {
         nodeGeometryWeights[weightCounter++] = [weight floatValue];
         // NSLog(@" adding weight: %f", weight.floatValue);
       }
-      for (int k = 0; k < zeroWeights; k++) {
+      for (int k = 0; k < zeroWeights; k++)
+      {
         nodeGeometryWeights[weightCounter++] = 0.0;
       }
     }
@@ -942,67 +1056,76 @@ makeBoneWeightsGeometrySourceAtNode:(const struct aiNode*)aiNode
   NSLog(@" weight counter %d", weightCounter);
   assert(weightCounter == nVertices * maxWeights);
 
-  SCNGeometrySource* boneWeightsSource = [SCNGeometrySource
-    geometrySourceWithData:[NSData dataWithBytes:nodeGeometryWeights
-                                          length:nVertices * maxWeights *
-                                                 sizeof(float)]
-                  semantic:SCNGeometrySourceSemanticBoneWeights
-               vectorCount:nVertices
-           floatComponents:YES
-       componentsPerVector:maxWeights
-         bytesPerComponent:sizeof(float)
-                dataOffset:0
-                dataStride:maxWeights * sizeof(float)];
+  SCNGeometrySource *boneWeightsSource = [SCNGeometrySource
+      geometrySourceWithData:[NSData dataWithBytes:nodeGeometryWeights
+                                            length:nVertices * maxWeights *
+                                                   sizeof(float)]
+                    semantic:SCNGeometrySourceSemanticBoneWeights
+                 vectorCount:nVertices
+             floatComponents:YES
+         componentsPerVector:maxWeights
+           bytesPerComponent:sizeof(float)
+                  dataOffset:0
+                  dataStride:maxWeights * sizeof(float)];
   return boneWeightsSource;
 }
 
-- (SCNGeometrySource*)
-makeBoneIndicesGeometrySourceAtNode:(const struct aiNode*)aiNode
-                            inScene:(const struct aiScene*)aiScene
+- (SCNGeometrySource *)
+makeBoneIndicesGeometrySourceAtNode:(const struct aiNode *)aiNode
+                            inScene:(const struct aiScene *)aiScene
                        withVertices:(int)nVertices
                          maxWeights:(int)maxWeights
-                          boneNames:(NSArray*)boneNames
+                          boneNames:(NSArray *)boneNames
 {
   NSLog(@" |--| Making bone indices geometry source: %@", boneNames);
   short nodeGeometryBoneIndices[nVertices * maxWeights];
   int indexCounter = 0;
 
-  for (int i = 0; i < aiNode->mNumMeshes; i++) {
+  for (int i = 0; i < aiNode->mNumMeshes; i++)
+  {
     int aiMeshIndex = aiNode->mMeshes[i];
-    const struct aiMesh* aiMesh = aiScene->mMeshes[aiMeshIndex];
-    NSMutableDictionary* meshBoneIndices = [[NSMutableDictionary alloc] init];
-    for (int j = 0; j < aiMesh->mNumBones; j++) {
-      const struct aiBone* aiBone = aiMesh->mBones[j];
-      for (int k = 0; k < aiBone->mNumWeights; k++) {
-        const struct aiVertexWeight* aiVertexWeight = &aiBone->mWeights[k];
-        NSNumber* vertex = [NSNumber numberWithInt:aiVertexWeight->mVertexId];
+    const struct aiMesh *aiMesh = aiScene->mMeshes[aiMeshIndex];
+    NSMutableDictionary *meshBoneIndices = [[NSMutableDictionary alloc] init];
+    for (int j = 0; j < aiMesh->mNumBones; j++)
+    {
+      const struct aiBone *aiBone = aiMesh->mBones[j];
+      for (int k = 0; k < aiBone->mNumWeights; k++)
+      {
+        const struct aiVertexWeight *aiVertexWeight = &aiBone->mWeights[k];
+        NSNumber *vertex = [NSNumber numberWithInt:aiVertexWeight->mVertexId];
         const struct aiString name = aiBone->mName;
-        NSString* boneName = [NSString stringWithUTF8String:&name.data];
-        NSNumber* boneIndex =
-          [NSNumber numberWithInteger:[boneNames indexOfObject:boneName]];
-        if ([meshBoneIndices valueForKey:vertex.stringValue] == nil) {
-          NSMutableArray* boneIndices = [[NSMutableArray alloc] init];
+        NSString *boneName = [NSString stringWithUTF8String:&name.data];
+        NSNumber *boneIndex =
+            [NSNumber numberWithInteger:[boneNames indexOfObject:boneName]];
+        if ([meshBoneIndices valueForKey:vertex.stringValue] == nil)
+        {
+          NSMutableArray *boneIndices = [[NSMutableArray alloc] init];
           [boneIndices addObject:boneIndex];
           [meshBoneIndices setValue:boneIndices forKey:vertex.stringValue];
-        } else {
-          NSMutableArray* boneIndices =
-            [meshBoneIndices valueForKey:vertex.stringValue];
+        }
+        else
+        {
+          NSMutableArray *boneIndices =
+              [meshBoneIndices valueForKey:vertex.stringValue];
           [boneIndices addObject:boneIndex];
         }
       }
     }
 
     // Add bone indices to the indices array for the entire node geometry
-    for (int j = 0; j < aiMesh->mNumVertices; j++) {
-      NSNumber* vertex = [NSNumber numberWithInt:j];
-      NSMutableArray* boneIndices =
-        [meshBoneIndices valueForKey:vertex.stringValue];
+    for (int j = 0; j < aiMesh->mNumVertices; j++)
+    {
+      NSNumber *vertex = [NSNumber numberWithInt:j];
+      NSMutableArray *boneIndices =
+          [meshBoneIndices valueForKey:vertex.stringValue];
       int zeroIndices = maxWeights - boneIndices.count;
-      for (NSNumber* boneIndex in boneIndices) {
+      for (NSNumber *boneIndex in boneIndices)
+      {
         nodeGeometryBoneIndices[indexCounter++] = [boneIndex shortValue];
         // NSLog(@"  adding bone index: %d", boneIndex.shortValue);
       }
-      for (int k = 0; k < zeroIndices; k++) {
+      for (int k = 0; k < zeroIndices; k++)
+      {
         nodeGeometryBoneIndices[indexCounter++] = 0;
       }
     }
@@ -1010,28 +1133,29 @@ makeBoneIndicesGeometrySourceAtNode:(const struct aiNode*)aiNode
 
   assert(indexCounter == nVertices * maxWeights);
 
-  SCNGeometrySource* boneIndicesSource = [SCNGeometrySource
-    geometrySourceWithData:[NSData dataWithBytes:nodeGeometryBoneIndices
-                                          length:nVertices * maxWeights *
-                                                 sizeof(short)]
-                  semantic:SCNGeometrySourceSemanticBoneIndices
-               vectorCount:nVertices
-           floatComponents:NO
-       componentsPerVector:maxWeights
-         bytesPerComponent:sizeof(short)
-                dataOffset:0
-                dataStride:maxWeights * sizeof(short)];
+  SCNGeometrySource *boneIndicesSource = [SCNGeometrySource
+      geometrySourceWithData:[NSData dataWithBytes:nodeGeometryBoneIndices
+                                            length:nVertices * maxWeights *
+                                                   sizeof(short)]
+                    semantic:SCNGeometrySourceSemanticBoneIndices
+                 vectorCount:nVertices
+             floatComponents:NO
+         componentsPerVector:maxWeights
+           bytesPerComponent:sizeof(short)
+                  dataOffset:0
+                  dataStride:maxWeights * sizeof(short)];
   return boneIndicesSource;
 }
 
-- (void)buildSkeletonDatabaseForScene:(SCNScene*)scene
+- (void)buildSkeletonDatabaseForScene:(SCNScene *)scene
 {
   self.uniqueBoneNames = [[NSSet setWithArray:self.boneNames] allObjects];
   NSLog(@" |--| bone names %lu: %@", self.boneNames.count, self.boneNames);
   NSLog(@" |--| unique bone names %lu: %@", self.uniqueBoneNames.count,
         self.uniqueBoneNames);
   self.uniqueBoneNodes =
-    [self findBoneNodesInScene:scene forBones:self.uniqueBoneNames];
+      [self findBoneNodesInScene:scene
+                        forBones:self.uniqueBoneNames];
   NSLog(@" |--| unique bone nodes %lu: %@", self.uniqueBoneNodes.count,
         self.uniqueBoneNodes);
   self.uniqueBoneTransforms = [self getTransformsForBones:self.uniqueBoneNames
@@ -1042,102 +1166,110 @@ makeBoneIndicesGeometrySourceAtNode:(const struct aiNode*)aiNode
   NSLog(@" |--| skeleton bone is : %@", self.skelton);
 }
 
-- (void)makeSkinnerForAssimpNode:(const struct aiNode*)aiNode
-                         inScene:(const struct aiScene*)aiScene
-                        scnScene:(SCNScene*)scene
+- (void)makeSkinnerForAssimpNode:(const struct aiNode *)aiNode
+                         inScene:(const struct aiScene *)aiScene
+                        scnScene:(SCNScene *)scene
 {
   int nBones = [self findNumBonesInNode:aiNode inScene:aiScene];
-  const struct aiString* aiNodeName = &aiNode->mName;
-  NSString* nodeName = [NSString stringWithUTF8String:aiNodeName->data];
-  if (nBones > 0) {
+  const struct aiString *aiNodeName = &aiNode->mName;
+  NSString *nodeName = [NSString stringWithUTF8String:aiNodeName->data];
+  if (nBones > 0)
+  {
     int nVertices = [self findNumVerticesInNode:aiNode inScene:aiScene];
     int maxWeights = [self findMaxWeightsForNode:aiNode inScene:aiScene];
     NSLog(@" |--| Making Skinner for node: %@ vertices: %d max-weights: %d "
           @"nBones: %d",
           nodeName, nVertices, maxWeights, nBones);
 
-    SCNGeometrySource* boneWeights =
-      [self makeBoneWeightsGeometrySourceAtNode:aiNode
-                                        inScene:aiScene
-                                   withVertices:nVertices
-                                     maxWeights:maxWeights];
-    SCNGeometrySource* boneIndices =
-      [self makeBoneIndicesGeometrySourceAtNode:aiNode
-                                        inScene:aiScene
-                                   withVertices:nVertices
-                                     maxWeights:maxWeights
-                                      boneNames:self.uniqueBoneNames];
+    SCNGeometrySource *boneWeights =
+        [self makeBoneWeightsGeometrySourceAtNode:aiNode
+                                          inScene:aiScene
+                                     withVertices:nVertices
+                                       maxWeights:maxWeights];
+    SCNGeometrySource *boneIndices =
+        [self makeBoneIndicesGeometrySourceAtNode:aiNode
+                                          inScene:aiScene
+                                     withVertices:nVertices
+                                       maxWeights:maxWeights
+                                        boneNames:self.uniqueBoneNames];
 
-    SCNNode* node = [scene.rootNode childNodeWithName:nodeName recursively:YES];
-    SCNSkinner* skinner =
-      [SCNSkinner skinnerWithBaseGeometry:node.geometry
-                                    bones:self.uniqueBoneNodes
-                boneInverseBindTransforms:self.uniqueBoneTransforms
-                              boneWeights:boneWeights
-                              boneIndices:boneIndices];
+    SCNNode *node = [scene.rootNode childNodeWithName:nodeName recursively:YES];
+    SCNSkinner *skinner =
+        [SCNSkinner skinnerWithBaseGeometry:node.geometry
+                                      bones:self.uniqueBoneNodes
+                  boneInverseBindTransforms:self.uniqueBoneTransforms
+                                boneWeights:boneWeights
+                                boneIndices:boneIndices];
     skinner.skeleton = self.skelton;
     NSLog(@" assigned skinner %@ skeleton: %@", skinner, skinner.skeleton);
     node.skinner = skinner;
   }
 
-  for (int i = 0; i < aiNode->mNumChildren; i++) {
-    const struct aiNode* aiChildNode = aiNode->mChildren[i];
+  for (int i = 0; i < aiNode->mNumChildren; i++)
+  {
+    const struct aiNode *aiChildNode = aiNode->mChildren[i];
     [self makeSkinnerForAssimpNode:aiChildNode inScene:aiScene scnScene:scene];
   }
 }
 
 #pragma mark - Animations
 
-- (void)createAnimationsFromScene:(const struct aiScene*)aiScene
-                        withScene:(SCNAssimpScene*)scene
-                           atPath:(NSString*)path
+- (void)createAnimationsFromScene:(const struct aiScene *)aiScene
+                        withScene:(SCNAssimpScene *)scene
+                           atPath:(NSString *)path
 {
   NSLog(@" ========= Number of animations in scene: %d",
         aiScene->mNumAnimations);
-  for (int i = 0; i < aiScene->mNumAnimations; i++) {
+  for (int i = 0; i < aiScene->mNumAnimations; i++)
+  {
     NSLog(@"--- Animation data for animation at index: %d", i);
-    const struct aiAnimation* aiAnimation = aiScene->mAnimations[i];
-    NSString* animName = [[[path lastPathComponent]
-      stringByDeletingPathExtension] stringByAppendingString:@"-1"];
+    const struct aiAnimation *aiAnimation = aiScene->mAnimations[i];
+    NSString *animName = [[[path lastPathComponent]
+        stringByDeletingPathExtension] stringByAppendingString:@"-1"];
     NSLog(@" Generated animation name: %@", animName);
-    NSMutableDictionary* currentAnimation = [[NSMutableDictionary alloc] init];
+    NSMutableDictionary *currentAnimation = [[NSMutableDictionary alloc] init];
     NSLog(
-      @" This animation %@ has %d channels with duration %f ticks per sec: %f",
-      animName, aiAnimation->mNumChannels, aiAnimation->mDuration,
-      aiAnimation->mTicksPerSecond);
+        @" This animation %@ has %d channels with duration %f ticks per sec: %f",
+        animName, aiAnimation->mNumChannels, aiAnimation->mDuration,
+        aiAnimation->mTicksPerSecond);
     float duration;
-    if (aiAnimation->mTicksPerSecond != 0) {
+    if (aiAnimation->mTicksPerSecond != 0)
+    {
       duration = aiAnimation->mDuration / aiAnimation->mTicksPerSecond;
-    } else {
+    }
+    else
+    {
       duration = aiAnimation->mDuration;
     }
-    for (int j = 0; j < aiAnimation->mNumChannels; j++) {
-      const struct aiNodeAnim* aiNodeAnim = aiAnimation->mChannels[j];
-      const struct aiString* aiNodeName = &aiNodeAnim->mNodeName;
-      NSString* name = [NSString stringWithUTF8String:aiNodeName->data];
+    for (int j = 0; j < aiAnimation->mNumChannels; j++)
+    {
+      const struct aiNodeAnim *aiNodeAnim = aiAnimation->mChannels[j];
+      const struct aiString *aiNodeName = &aiNodeAnim->mNodeName;
+      NSString *name = [NSString stringWithUTF8String:aiNodeName->data];
       NSLog(@" The channel %@ has data for %d position, %d rotation, %d scale "
             @"keyframes",
             name, aiNodeAnim->mNumPositionKeys, aiNodeAnim->mNumRotationKeys,
             aiNodeAnim->mNumScalingKeys);
 
       // create a lookup for all animation keys
-      NSMutableDictionary* channelKeys = [[NSMutableDictionary alloc] init];
+      NSMutableDictionary *channelKeys = [[NSMutableDictionary alloc] init];
 
       // create translation animation
-      NSMutableArray* translationValues = [[NSMutableArray alloc] init];
-      NSMutableArray* translationTimes = [[NSMutableArray alloc] init];
-      for (int k = 0; k < aiNodeAnim->mNumPositionKeys; k++) {
-        const struct aiVectorKey* aiTranslationKey =
-          &aiNodeAnim->mPositionKeys[k];
+      NSMutableArray *translationValues = [[NSMutableArray alloc] init];
+      NSMutableArray *translationTimes = [[NSMutableArray alloc] init];
+      for (int k = 0; k < aiNodeAnim->mNumPositionKeys; k++)
+      {
+        const struct aiVectorKey *aiTranslationKey =
+            &aiNodeAnim->mPositionKeys[k];
         double keyTime = aiTranslationKey->mTime;
         const struct aiVector3D aiTranslation = aiTranslationKey->mValue;
         [translationTimes addObject:[NSNumber numberWithFloat:keyTime]];
         SCNVector3 pos =
-          SCNVector3Make(aiTranslation.x, aiTranslation.y, aiTranslation.z);
+            SCNVector3Make(aiTranslation.x, aiTranslation.y, aiTranslation.z);
         [translationValues addObject:[NSValue valueWithSCNVector3:pos]];
       }
-      CAKeyframeAnimation* translationKeyFrameAnim =
-        [CAKeyframeAnimation animationWithKeyPath:@"position"];
+      CAKeyframeAnimation *translationKeyFrameAnim =
+          [CAKeyframeAnimation animationWithKeyPath:@"position"];
       translationKeyFrameAnim.values = translationValues;
       translationKeyFrameAnim.keyTimes = translationTimes;
       translationKeyFrameAnim.speed = 1;
@@ -1146,10 +1278,11 @@ makeBoneIndicesGeometrySourceAtNode:(const struct aiNode*)aiNode
       [channelKeys setValue:translationKeyFrameAnim forKey:@"position"];
 
       // create rotation animation
-      NSMutableArray* rotationValues = [[NSMutableArray alloc] init];
-      NSMutableArray* rotationTimes = [[NSMutableArray alloc] init];
-      for (int k = 0; k < aiNodeAnim->mNumRotationKeys; k++) {
-        const struct aiQuatKey* aiQuatKey = &aiNodeAnim->mRotationKeys[k];
+      NSMutableArray *rotationValues = [[NSMutableArray alloc] init];
+      NSMutableArray *rotationTimes = [[NSMutableArray alloc] init];
+      for (int k = 0; k < aiNodeAnim->mNumRotationKeys; k++)
+      {
+        const struct aiQuatKey *aiQuatKey = &aiNodeAnim->mRotationKeys[k];
         double keyTime = aiQuatKey->mTime;
         const struct aiQuaternion aiQuaternion = aiQuatKey->mValue;
         [rotationTimes addObject:[NSNumber numberWithFloat:keyTime]];
@@ -1157,8 +1290,8 @@ makeBoneIndicesGeometrySourceAtNode:(const struct aiNode*)aiNode
                                          aiQuaternion.z, aiQuaternion.w);
         [rotationValues addObject:[NSValue valueWithSCNVector4:quat]];
       }
-      CAKeyframeAnimation* rotationKeyFrameAnim =
-        [CAKeyframeAnimation animationWithKeyPath:@"orientation"];
+      CAKeyframeAnimation *rotationKeyFrameAnim =
+          [CAKeyframeAnimation animationWithKeyPath:@"orientation"];
       rotationKeyFrameAnim.values = rotationValues;
       rotationKeyFrameAnim.keyTimes = rotationTimes;
       rotationKeyFrameAnim.speed = 1;
@@ -1167,18 +1300,19 @@ makeBoneIndicesGeometrySourceAtNode:(const struct aiNode*)aiNode
       [channelKeys setValue:rotationKeyFrameAnim forKey:@"orientation"];
 
       // create scale animation
-      NSMutableArray* scaleValues = [[NSMutableArray alloc] init];
-      NSMutableArray* scaleTimes = [[NSMutableArray alloc] init];
-      for (int k = 0; k < aiNodeAnim->mNumScalingKeys; k++) {
-        const struct aiVectorKey* aiScaleKey = &aiNodeAnim->mScalingKeys[k];
+      NSMutableArray *scaleValues = [[NSMutableArray alloc] init];
+      NSMutableArray *scaleTimes = [[NSMutableArray alloc] init];
+      for (int k = 0; k < aiNodeAnim->mNumScalingKeys; k++)
+      {
+        const struct aiVectorKey *aiScaleKey = &aiNodeAnim->mScalingKeys[k];
         double keyTime = aiScaleKey->mTime;
         const struct aiVector3D aiScale = aiScaleKey->mValue;
         [scaleTimes addObject:[NSNumber numberWithFloat:keyTime]];
         SCNVector3 scale = SCNVector3Make(aiScale.x, aiScale.y, aiScale.z);
         [scaleValues addObject:[NSValue valueWithSCNVector3:scale]];
       }
-      CAKeyframeAnimation* scaleKeyFrameAnim =
-        [CAKeyframeAnimation animationWithKeyPath:@"scale"];
+      CAKeyframeAnimation *scaleKeyFrameAnim =
+          [CAKeyframeAnimation animationWithKeyPath:@"scale"];
       scaleKeyFrameAnim.values = scaleValues;
       scaleKeyFrameAnim.keyTimes = scaleTimes;
       scaleKeyFrameAnim.speed = 1;
@@ -1189,9 +1323,9 @@ makeBoneIndicesGeometrySourceAtNode:(const struct aiNode*)aiNode
       [currentAnimation setValue:channelKeys forKey:name];
     }
 
-    SCNAssimpAnimation* animation =
-      [[SCNAssimpAnimation alloc] initWithKey:animName
-                                   frameAnims:currentAnimation];
+    SCNAssimpAnimation *animation =
+        [[SCNAssimpAnimation alloc] initWithKey:animName
+                                     frameAnims:currentAnimation];
     [scene.animations setValue:animation forKey:animName];
   }
 }

--- a/AssimpKit/Code/Model/SCNAssimpAnimation.h
+++ b/AssimpKit/Code/Model/SCNAssimpAnimation.h
@@ -10,9 +10,9 @@
 
 @interface SCNAssimpAnimation : SCNScene
 
-@property (readonly, nonatomic) NSString* key;
-@property (readonly, nonatomic) NSDictionary* frameAnims;
+@property (readonly, nonatomic) NSString *key;
+@property (readonly, nonatomic) NSDictionary *frameAnims;
 
-- (id)initWithKey:(NSString*)key frameAnims:(NSDictionary*)anims;
+- (id)initWithKey:(NSString *)key frameAnims:(NSDictionary *)anims;
 
 @end

--- a/AssimpKit/Code/Model/SCNAssimpAnimation.m
+++ b/AssimpKit/Code/Model/SCNAssimpAnimation.m
@@ -8,20 +8,20 @@
 
 #import "SCNAssimpAnimation.h"
 
-@interface
-SCNAssimpAnimation ()
+@interface SCNAssimpAnimation ()
 
-@property (readwrite, nonatomic) NSString* key;
-@property (readwrite, nonatomic) NSDictionary* frameAnims;
+@property (readwrite, nonatomic) NSString *key;
+@property (readwrite, nonatomic) NSDictionary *frameAnims;
 
 @end
 
 @implementation SCNAssimpAnimation
 
-- (id)initWithKey:(NSString*)key frameAnims:(NSDictionary*)anims
+- (id)initWithKey:(NSString *)key frameAnims:(NSDictionary *)anims
 {
   self = [super init];
-  if (self) {
+  if (self)
+  {
     self.key = key;
     self.frameAnims = anims;
   }

--- a/AssimpKit/Code/Model/SCNAssimpScene.h
+++ b/AssimpKit/Code/Model/SCNAssimpScene.h
@@ -11,9 +11,9 @@
 
 @interface SCNAssimpScene : SCNScene
 
-@property (readonly, nonatomic) NSMutableDictionary* animations;
+@property (readonly, nonatomic) NSMutableDictionary *animations;
 
-- (void)addAnimation:(SCNAssimpAnimation*)assimpAnimation;
-- (SCNAssimpAnimation*)animationForKey:(NSString*)key;
+- (void)addAnimation:(SCNAssimpAnimation *)assimpAnimation;
+- (SCNAssimpAnimation *)animationForKey:(NSString *)key;
 
 @end

--- a/AssimpKit/Code/Model/SCNAssimpScene.m
+++ b/AssimpKit/Code/Model/SCNAssimpScene.m
@@ -8,10 +8,9 @@
 
 #import "SCNAssimpScene.h"
 
-@interface
-SCNAssimpScene ()
+@interface SCNAssimpScene ()
 
-@property (readwrite, nonatomic) NSMutableDictionary* animations;
+@property (readwrite, nonatomic) NSMutableDictionary *animations;
 
 @end
 
@@ -20,40 +19,46 @@ SCNAssimpScene ()
 - (id)init
 {
   self = [super init];
-  if (self) {
+  if (self)
+  {
     self.animations = [[NSMutableDictionary alloc] init];
   }
   return self;
 }
 
-- (void)addAnimation:(SCNAssimpAnimation*)assimpAnimation
+- (void)addAnimation:(SCNAssimpAnimation *)assimpAnimation
 {
-  NSDictionary* frameAnims = assimpAnimation.frameAnims;
-  for (NSString* nodeName in frameAnims.allKeys) {
-    SCNNode* boneNode =
-      [self.rootNode childNodeWithName:nodeName recursively:YES];
-    NSDictionary* channelKeys = [frameAnims valueForKey:nodeName];
-    CAKeyframeAnimation* posAnim = [channelKeys valueForKey:@"position"];
-    CAKeyframeAnimation* quatAnim = [channelKeys valueForKey:@"orientation"];
-    CAKeyframeAnimation* scaleAnim = [channelKeys valueForKey:@"scale"];
+  NSDictionary *frameAnims = assimpAnimation.frameAnims;
+  for (NSString *nodeName in frameAnims.allKeys)
+  {
+    SCNNode *boneNode =
+        [self.rootNode childNodeWithName:nodeName
+                             recursively:YES];
+    NSDictionary *channelKeys = [frameAnims valueForKey:nodeName];
+    CAKeyframeAnimation *posAnim = [channelKeys valueForKey:@"position"];
+    CAKeyframeAnimation *quatAnim = [channelKeys valueForKey:@"orientation"];
+    CAKeyframeAnimation *scaleAnim = [channelKeys valueForKey:@"scale"];
     NSLog(@" for node %@ pos anim is %@ quat anim is %@", boneNode, posAnim,
           quatAnim);
-    if (posAnim) {
+    if (posAnim)
+    {
       [boneNode addAnimation:posAnim
                       forKey:[nodeName stringByAppendingString:@"-pos"]];
     }
-    if (quatAnim) {
+    if (quatAnim)
+    {
       [boneNode addAnimation:quatAnim
                       forKey:[nodeName stringByAppendingString:@"-quat"]];
     }
-    if (scaleAnim) {
+    if (scaleAnim)
+    {
       [boneNode addAnimation:scaleAnim
                       forKey:[nodeName stringByAppendingString:@"-scale"]];
     }
   }
 }
 
-- (SCNAssimpAnimation*)animationForKey:(NSString*)key
+- (SCNAssimpAnimation *)animationForKey:(NSString *)key
 {
   return [self.animations valueForKey:key];
 }

--- a/AssimpKit/Code/Model/SCNScene+AssimpImport.h
+++ b/AssimpKit/Code/Model/SCNScene+AssimpImport.h
@@ -12,7 +12,7 @@
 
 @interface SCNScene (AssimpImport)
 
-+ (SCNAssimpScene*)assimpSceneNamed:(NSString*)name;
-+ (SCNAssimpScene*)assimpSceneWithURL:(NSURL*)url;
++ (SCNAssimpScene *)assimpSceneNamed:(NSString *)name;
++ (SCNAssimpScene *)assimpSceneWithURL:(NSURL *)url;
 
 @end

--- a/AssimpKit/Code/Model/SCNScene+AssimpImport.m
+++ b/AssimpKit/Code/Model/SCNScene+AssimpImport.m
@@ -13,16 +13,16 @@
 
 #pragma mark - Loading a Scene
 
-+ (SCNAssimpScene*)assimpSceneNamed:(NSString*)name
++ (SCNAssimpScene *)assimpSceneNamed:(NSString *)name
 {
-  AssimpImporter* assimpImporter = [[AssimpImporter alloc] init];
-  NSString* file = [[NSBundle mainBundle] pathForResource:name ofType:nil];
+  AssimpImporter *assimpImporter = [[AssimpImporter alloc] init];
+  NSString *file = [[NSBundle mainBundle] pathForResource:name ofType:nil];
   return [assimpImporter importScene:file];
 }
 
-+ (SCNAssimpScene*)assimpSceneWithURL:(NSURL*)url
++ (SCNAssimpScene *)assimpSceneWithURL:(NSURL *)url
 {
-  AssimpImporter* assimpImporter = [[AssimpImporter alloc] init];
+  AssimpImporter *assimpImporter = [[AssimpImporter alloc] init];
   return [assimpImporter importScene:url.path];
 }
 

--- a/AssimpKit/OSX-ObjC-Example/AppDelegate.h
+++ b/AssimpKit/OSX-ObjC-Example/AppDelegate.h
@@ -8,8 +8,8 @@
 
 #import <Cocoa/Cocoa.h>
 
-@interface AppDelegate : NSObject<NSApplicationDelegate>
+@interface AppDelegate : NSObject <NSApplicationDelegate>
 
-@property (assign) IBOutlet NSWindow* window;
+@property (assign) IBOutlet NSWindow *window;
 
 @end

--- a/AssimpKit/OSX-ObjC-Example/AppDelegate.m
+++ b/AssimpKit/OSX-ObjC-Example/AppDelegate.m
@@ -10,7 +10,7 @@
 
 @implementation AppDelegate
 
-- (void)applicationDidFinishLaunching:(NSNotification*)aNotification
+- (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
   // Insert code here to initialize your application
 }

--- a/AssimpKit/OSX-ObjC-Example/GameViewController.h
+++ b/AssimpKit/OSX-ObjC-Example/GameViewController.h
@@ -12,6 +12,6 @@
 
 @interface GameViewController : NSViewController
 
-@property (assign) IBOutlet GameView* gameView;
+@property (assign) IBOutlet GameView *gameView;
 
 @end

--- a/AssimpKit/OSX-ObjC-Example/GameViewController.m
+++ b/AssimpKit/OSX-ObjC-Example/GameViewController.m
@@ -15,12 +15,12 @@
 {
   //  NSString* filePath = @"/Users/deepaksurti/ios-osx/assimp/demo/assets/"
   // @"models-nonbsd/3DS/jeep1.3ds";
-  NSString* filePath =
-    @"/Users/deepaksurti/ios-osx/assimp/demo/assets/astroBoy_walk.dae";
-  SCNAssimpScene* scene =
-    [SCNScene assimpSceneWithURL:[NSURL URLWithString:filePath]];
+  NSString *filePath =
+      @"/Users/deepaksurti/ios-osx/assimp/demo/assets/astroBoy_walk.dae";
+  SCNAssimpScene *scene =
+      [SCNScene assimpSceneWithURL:[NSURL URLWithString:filePath]];
   // SCNScene* scene = [SCNScene assimpSceneNamed:@"spider.obj"];
-  SCNAssimpAnimation* walkAnim = [scene animationForKey:@"astroBoy_walk-1"];
+  SCNAssimpAnimation *walkAnim = [scene animationForKey:@"astroBoy_walk-1"];
   [scene addAnimation:walkAnim];
 
   self.gameView.scene = scene;

--- a/AssimpKit/OSX-ObjC-Example/main.m
+++ b/AssimpKit/OSX-ObjC-Example/main.m
@@ -8,8 +8,7 @@
 
 #import <Cocoa/Cocoa.h>
 
-int
-main(int argc, const char* argv[])
+int main(int argc, const char *argv[])
 {
   return NSApplicationMain(argc, argv);
 }

--- a/AssimpKit/iOS-ObjC-Example/AppDelegate.h
+++ b/AssimpKit/iOS-ObjC-Example/AppDelegate.h
@@ -8,8 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
-@interface AppDelegate : UIResponder<UIApplicationDelegate>
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
 
-@property (strong, nonatomic) UIWindow* window;
+@property (strong, nonatomic) UIWindow *window;
 
 @end

--- a/AssimpKit/iOS-ObjC-Example/AppDelegate.m
+++ b/AssimpKit/iOS-ObjC-Example/AppDelegate.m
@@ -8,21 +8,20 @@
 
 #import "AppDelegate.h"
 
-@interface
-AppDelegate ()
+@interface AppDelegate ()
 
 @end
 
 @implementation AppDelegate
 
-- (BOOL)application:(UIApplication*)application
-  didFinishLaunchingWithOptions:(NSDictionary*)launchOptions
+- (BOOL)application:(UIApplication *)application
+    didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   // Override point for customization after application launch.
   return YES;
 }
 
-- (void)applicationWillResignActive:(UIApplication*)application
+- (void)applicationWillResignActive:(UIApplication *)application
 {
   // Sent when the application is about to move from active to inactive state.
   // This can occur for certain types of temporary interruptions (such as an
@@ -32,7 +31,7 @@ AppDelegate ()
   // OpenGL ES frame rates. Games should use this method to pause the game.
 }
 
-- (void)applicationDidEnterBackground:(UIApplication*)application
+- (void)applicationDidEnterBackground:(UIApplication *)application
 {
   // Use this method to release shared resources, save user data, invalidate
   // timers, and store enough application state information to restore your
@@ -41,20 +40,20 @@ AppDelegate ()
   // instead of applicationWillTerminate: when the user quits.
 }
 
-- (void)applicationWillEnterForeground:(UIApplication*)application
+- (void)applicationWillEnterForeground:(UIApplication *)application
 {
   // Called as part of the transition from the background to the inactive state;
   // here you can undo many of the changes made on entering the background.
 }
 
-- (void)applicationDidBecomeActive:(UIApplication*)application
+- (void)applicationDidBecomeActive:(UIApplication *)application
 {
   // Restart any tasks that were paused (or not yet started) while the
   // application was inactive. If the application was previously in the
   // background, optionally refresh the user interface.
 }
 
-- (void)applicationWillTerminate:(UIApplication*)application
+- (void)applicationWillTerminate:(UIApplication *)application
 {
   // Called when the application is about to terminate. Save data if
   // appropriate. See also applicationDidEnterBackground:.

--- a/AssimpKit/iOS-ObjC-Example/GameViewController.m
+++ b/AssimpKit/iOS-ObjC-Example/GameViewController.m
@@ -16,28 +16,28 @@
 {
   [super viewDidLoad];
 
-  NSArray* paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory,
+  NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory,
                                                        NSUserDomainMask, YES);
-  NSString* docsDir = [paths objectAtIndex:0];
-  NSString* explorer =
-    [docsDir stringByAppendingString:@"/explorer_skinned.dae"];
-  NSString* bob = [docsDir stringByAppendingString:@"/Bob.md5mesh"];
-  SCNAssimpScene* scene =
-    [SCNScene assimpSceneWithURL:[NSURL URLWithString:bob]];
+  NSString *docsDir = [paths objectAtIndex:0];
+  NSString *explorer =
+      [docsDir stringByAppendingString:@"/explorer_skinned.dae"];
+  NSString *bob = [docsDir stringByAppendingString:@"/Bob.md5mesh"];
+  SCNAssimpScene *scene =
+      [SCNScene assimpSceneWithURL:[NSURL URLWithString:bob]];
 
   // Now we can access the file's contents
-  NSString* runAnim =
-    [docsDir stringByAppendingString:@"/explorer/jump_start.dae"];
-  NSString* bobAnim = [docsDir stringByAppendingString:@"/Bob.md5anim"];
-  AssimpImporter* assimpImporter = [[AssimpImporter alloc] init];
-  SCNAssimpScene* jumpStartScene = [assimpImporter importScene:bobAnim];
-  NSString* bobId = @"Bob-1";
-  NSString* jumpId = @"jump_start-1";
-  SCNAssimpAnimation* jumpStartAnim = [jumpStartScene animationForKey:bobId];
+  NSString *runAnim =
+      [docsDir stringByAppendingString:@"/explorer/jump_start.dae"];
+  NSString *bobAnim = [docsDir stringByAppendingString:@"/Bob.md5anim"];
+  AssimpImporter *assimpImporter = [[AssimpImporter alloc] init];
+  SCNAssimpScene *jumpStartScene = [assimpImporter importScene:bobAnim];
+  NSString *bobId = @"Bob-1";
+  NSString *jumpId = @"jump_start-1";
+  SCNAssimpAnimation *jumpStartAnim = [jumpStartScene animationForKey:bobId];
   [scene addAnimation:jumpStartAnim];
 
   // retrieve the SCNView
-  SCNView* scnView = (SCNView*)self.view;
+  SCNView *scnView = (SCNView *)self.view;
 
   // set the scene to the view
   scnView.scene = scene;
@@ -67,9 +67,12 @@
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
   if ([[UIDevice currentDevice] userInterfaceIdiom] ==
-      UIUserInterfaceIdiomPhone) {
+      UIUserInterfaceIdiomPhone)
+  {
     return UIInterfaceOrientationMaskAllButUpsideDown;
-  } else {
+  }
+  else
+  {
     return UIInterfaceOrientationMaskAll;
   }
 }

--- a/AssimpKit/iOS-ObjC-Example/main.m
+++ b/AssimpKit/iOS-ObjC-Example/main.m
@@ -9,10 +9,10 @@
 #import "AppDelegate.h"
 #import <UIKit/UIKit.h>
 
-int
-main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
-  @autoreleasepool {
+  @autoreleasepool
+  {
     return UIApplicationMain(argc, argv, nil,
                              NSStringFromClass([AppDelegate class]));
   }


### PR DESCRIPTION
This updates to a simplified clang format. Reused the format from: http://tonyarnold.com/2014/05/31/autoformatting-your-code.html. I have changed the Indent to 2.

I have also integrated a behavior to format on save. I have this script from http://stackoverflow.com/questions/39747415/how-to-get-clang-format-for-xcode-8:

```
#!/bin/bash

CDP=$(osascript -e '
tell application "Xcode"
    activate
    tell application "System Events" to keystroke "s" using {command down}
    --wait for Xcode to remove edited flag from filename
    delay 0.3
    set last_word_in_main_window to (word -1 of (get name of window 1))
    set current_document to document 1 whose name ends with last_word_in_main_window
    set current_document_path to path of current_document
    --CDP is assigned last set value: current_document_path
end tell ')

LOGPATH=$(dirname "$0")
LOGNAME=formatWithClangLog.txt
echo "Filepath: ${CDP}" > ${LOGPATH}/${LOGNAME}
sleep 0.6 ### during save Xcode stops listening for file changes
/usr/local/bin/clang-format -style=file -i -sort-includes ${CDP} >> ${LOGPATH}/${LOGNAME} 2>&1

# EOF
```

All this pain after upgrading to Xcode 8 !!!