### PR TITLE
Add travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: objective-c
 script:
   - xcodebuild test -project AssimpKit/OSX-Example/OSX-Example.xcodeproj -scheme AssimpSceneKit_LogicTests -destination 'platform=OS X,arch=x86_64'
-  - xcodebuild test -project AssimpKit/iOS-Example/iOS-Example.xcodeproj -scheme AssimpSceneKit_LogicTests -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.1'
+  - xcodebuild test -project AssimpKit/iOS-Example/iOS-Example.xcodeproj -scheme AssimpSceneKit_LogicTests -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-language: objective-c
 osx_image: xcode8
+language: objective-c
 script:
   - xcodebuild test -project AssimpKit/OSX-Example/OSX-Example.xcodeproj -scheme AssimpSceneKit_LogicTests -destination 'platform=OS X,arch=x86_64'
-  - xcodebuild test -project AssimpKit/iOS-Example/iOS-Example.xcodeproj -scheme AssimpSceneKit_LogicTests -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0'
+  - xcodebuild test -project AssimpKit/iOS-Example/iOS-Example.xcodeproj -scheme AssimpSceneKit_LogicTests -sdk iphonesimulator10.0 -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 language: objective-c
 osx_image: xcode8
 script:
-#  - xcodebuild test -project AssimpKit/OSX-Example/OSX-Example.xcodeproj -scheme AssimpSceneKit_LogicTests -destination 'platform=OS X,arch=x86_64'
-  - xcodebuild -project AssimpKit/iOS-Example/iOS-Example.xcodeproj -scheme AssimpSceneKit_LogicTests -destination 'platform=iOS Simulator,OS=10.0,name=iPhone 6' clean build test | xcpretty -c --test --color 
+  - xcodebuild \
+      -project AssimpKit/OSX-Example/OSX-Example.xcodeproj \
+      -scheme AssimpSceneKit_LogicTests \
+      -destination 'platform=OS X,arch=x86_64'
+      clean build test | xcpretty -c --test --color 
+  - xcodebuild \
+      -project AssimpKit/iOS-Example/iOS-Example.xcodeproj \
+      -scheme AssimpSceneKit_LogicTests \
+      -destination 'platform=iOS Simulator,OS=10.0,name=iPhone 6' \
+      clean build test | xcpretty -c --test --color 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: objective-c
+osx_image: xcode8
 script:
   - xcodebuild test -project AssimpKit/OSX-Example/OSX-Example.xcodeproj -scheme AssimpSceneKit_LogicTests -destination 'platform=OS X,arch=x86_64'
   - xcodebuild test -project AssimpKit/iOS-Example/iOS-Example.xcodeproj -scheme AssimpSceneKit_LogicTests -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
 osx_image: xcode8
 script:
-  - xcodebuild test -project AssimpKit/OSX-Example/OSX-Example.xcodeproj -scheme AssimpSceneKit_LogicTests -destination 'platform=OS X,arch=x86_64'
-  - xcodebuild test -project AssimpKit/iOS-Example/iOS-Example.xcodeproj -scheme AssimpSceneKit_LogicTests -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0'
+#  - xcodebuild test -project AssimpKit/OSX-Example/OSX-Example.xcodeproj -scheme AssimpSceneKit_LogicTests -destination 'platform=OS X,arch=x86_64'
+  - xcodebuild -project AssimpKit/iOS-Example/iOS-Example.xcodeproj -scheme AssimpSceneKit_LogicTests -destination 'platform=iOS Simulator,OS=10.0,name=iPhone 6' clean build test | xcpretty -c --test --color 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-osx_image: xcode8
 language: objective-c
+osx_image: xcode8
 script:
   - xcodebuild test -project AssimpKit/OSX-Example/OSX-Example.xcodeproj -scheme AssimpSceneKit_LogicTests -destination 'platform=OS X,arch=x86_64'
-  - xcodebuild test -project AssimpKit/iOS-Example/iOS-Example.xcodeproj -scheme AssimpSceneKit_LogicTests -sdk iphonesimulator10.0 -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0'
+  - xcodebuild test -project AssimpKit/iOS-Example/iOS-Example.xcodeproj -scheme AssimpSceneKit_LogicTests -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: objective-c
+script:
+  - xcodebuild test -project AssimpKit/OSX-Example/OSX-Example.xcodeproj -scheme AssimpSceneKit_LogicTests -destination 'platform=OS X,arch=x86_64'
+  - xcodebuild test -project AssimpKit/iOS-Example/iOS-Example.xcodeproj -scheme AssimpSceneKit_LogicTests -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.1'

--- a/AssimpKit/Code/Model/Tests/AssimpImporterTests.m
+++ b/AssimpKit/Code/Model/Tests/AssimpImporterTests.m
@@ -535,7 +535,7 @@
                                            @"instead of %d key times",
                                            rotationAnim.keyTimes.count,
                                            aiNodeAnim->mNumRotationKeys];
-            [testLog addErrorLog:testLog];
+            [testLog addErrorLog:errorLog];
         }
         if (rotationAnim.values.count != aiNodeAnim->mNumRotationKeys)
         {
@@ -866,7 +866,7 @@
         {
             NSString *assetSubDir = [assetDir stringByAppendingString:subDir];
             NSLog(@"========== Scanning asset dir: %@", assetSubDir);
-            NSMutableArray *modelFiles =
+            NSArray *modelFiles =
                 [fileManager subpathsOfDirectoryAtPath:assetSubDir error:nil];
             for (NSString *modelFile in modelFiles)
             {

--- a/AssimpKit/iOS-Example/iOS-Example.xcodeproj/project.pbxproj
+++ b/AssimpKit/iOS-Example/iOS-Example.xcodeproj/project.pbxproj
@@ -479,6 +479,7 @@
 				DEVELOPMENT_TEAM = PRJ5CHFB5D;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "iOS-Example/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/ios";
 				OTHER_LDFLAGS = (
@@ -500,6 +501,7 @@
 				DEVELOPMENT_TEAM = PRJ5CHFB5D;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "iOS-Example/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/ios";
 				OTHER_LDFLAGS = (
@@ -618,6 +620,7 @@
 				77CDAB831DD745D800B7E342 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/AssimpKit/iOS-Example/iOS-Example.xcodeproj/xcshareddata/xcschemes/AssimpSceneKit_LogicTests.xcscheme
+++ b/AssimpKit/iOS-Example/iOS-Example.xcodeproj/xcshareddata/xcschemes/AssimpSceneKit_LogicTests.xcscheme
@@ -5,22 +5,6 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
-      <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "77CDAB161DD733E800B7E342"
-               BuildableName = "AssimpSceneKit_LogicTests.xctest"
-               BlueprintName = "AssimpSceneKit_LogicTests"
-               ReferencedContainer = "container:OSX-Example.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
@@ -32,10 +16,10 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "77CDAB161DD733E800B7E342"
+               BlueprintIdentifier = "77CDAB781DD745D800B7E342"
                BuildableName = "AssimpSceneKit_LogicTests.xctest"
                BlueprintName = "AssimpSceneKit_LogicTests"
-               ReferencedContainer = "container:OSX-Example.xcodeproj">
+               ReferencedContainer = "container:iOS-Example.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
@@ -52,15 +36,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "77CDAB161DD733E800B7E342"
-            BuildableName = "AssimpSceneKit_LogicTests.xctest"
-            BlueprintName = "AssimpSceneKit_LogicTests"
-            ReferencedContainer = "container:OSX-Example.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>


### PR DESCRIPTION
Fixes: #8 

This adds Travis CI support. Uses xcodebuild to run the logic tests for AssimpKit library on both OS X and iOS platforms.