### PR TITLE
Add log toggle

### DIFF
--- a/AssimpKit/Code/Model/AssimpImporter.m
+++ b/AssimpKit/Code/Model/AssimpImporter.m
@@ -82,8 +82,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     {
         NSString *errorString =
             [NSString stringWithUTF8String:aiGetErrorString()];
-        NSLog(@" Scene importing failed for filePath %@", filePath);
-        NSLog(@" Scene importing failed with error %@", errorString);
+        ALog(@" Scene importing failed for filePath %@", filePath);
+        ALog(@" Scene importing failed with error %@", errorString);
         return nil;
     }
     // Now we can access the file's contents

--- a/AssimpKit/Code/Model/AssimpSceneKit-Prefix.pch
+++ b/AssimpKit/Code/Model/AssimpSceneKit-Prefix.pch
@@ -1,0 +1,49 @@
+
+/*
+ ---------------------------------------------------------------------------
+ Assimp to Scene Kit Library (AssimpKit)
+ ---------------------------------------------------------------------------
+ Copyright (c) 2016, AssimpKit team
+ All rights reserved.
+ Redistribution and use of this software in source and binary forms,
+ with or without modification, are permitted provided that the following
+ conditions are met:
+ * Redistributions of source code must retain the above
+ copyright notice, this list of conditions and the
+ following disclaimer.
+ * Redistributions in binary form must reproduce the above
+ copyright notice, this list of conditions and the
+ following disclaimer in the documentation and/or other
+ materials provided with the distribution.
+ * Neither the name of the assimp team, nor the names of its
+ contributors may be used to endorse or promote products
+ derived from this software without specific prior
+ written permission of the assimp team.
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ---------------------------------------------------------------------------
+ */
+
+#ifdef __OBJC__
+    #import <Foundation/Foundation.h>
+
+    // #define MY_DEBUG 1
+    #ifdef MY_DEBUG
+    #	define NSLog(fmt, ...) NSLog((@"%s [Line %d] " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__);
+    #else
+    #	define NSLog(...)
+    #endif
+
+    // ALog always displays output regardless of the DEBUG setting
+    #define ALog(fmt, ...) NSLog((@"%s [Line %d] " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__);
+
+#endif

--- a/AssimpKit/Code/Model/Tests/AssimpImporterTests.m
+++ b/AssimpKit/Code/Model/Tests/AssimpImporterTests.m
@@ -906,7 +906,7 @@
     NSArray *modelFiles = [self getModelFiles];
     for (NSString *modelFilePath in modelFiles)
     {
-        NSLog(@"$$$$$$$$$$$ TESTING %@ file", modelFilePath);
+        NSLog(@"=== TESTING %@ file ===", modelFilePath);
         ModelLog *testLog = [[ModelLog alloc] init];
         [self checkModel:modelFilePath testLog:testLog];
         ++numFilesTested;

--- a/AssimpKit/OSX-Example/OSX-Example.xcodeproj/project.pbxproj
+++ b/AssimpKit/OSX-Example/OSX-Example.xcodeproj/project.pbxproj
@@ -553,6 +553,8 @@
 				DEVELOPMENT_TEAM = PRJ5CHFB5D;
 				EXECUTABLE_PREFIX = lib;
 				FRAMEWORK_SEARCH_PATHS = "";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/../Code/Model/AssimpSceneKit-Prefix.pch";
 				HEADER_SEARCH_PATHS = "";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/osx";
 				OTHER_LDFLAGS = "";
@@ -567,6 +569,8 @@
 				DEVELOPMENT_TEAM = PRJ5CHFB5D;
 				EXECUTABLE_PREFIX = lib;
 				FRAMEWORK_SEARCH_PATHS = "";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/../Code/Model/AssimpSceneKit-Prefix.pch";
 				HEADER_SEARCH_PATHS = "";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/osx";
 				OTHER_LDFLAGS = "";
@@ -581,6 +585,8 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = PRJ5CHFB5D;
 				FRAMEWORK_SEARCH_PATHS = "";
+				GCC_PRECOMPILE_PREFIX_HEADER = NO;
+				GCC_PREFIX_HEADER = "";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -605,6 +611,8 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = PRJ5CHFB5D;
 				FRAMEWORK_SEARCH_PATHS = "";
+				GCC_PRECOMPILE_PREFIX_HEADER = NO;
+				GCC_PREFIX_HEADER = "";
 				INFOPLIST_FILE = AssimpSceneKit_LogicTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/osx";

--- a/AssimpKit/iOS-Example/iOS-Example.xcodeproj/project.pbxproj
+++ b/AssimpKit/iOS-Example/iOS-Example.xcodeproj/project.pbxproj
@@ -521,6 +521,8 @@
 			buildSettings = {
 				DEVELOPMENT_TEAM = PRJ5CHFB5D;
 				ENABLE_BITCODE = NO;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/../Code/Model/AssimpSceneKit-Prefix.pch";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/ios";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -534,6 +536,8 @@
 			buildSettings = {
 				DEVELOPMENT_TEAM = PRJ5CHFB5D;
 				ENABLE_BITCODE = NO;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/../Code/Model/AssimpSceneKit-Prefix.pch";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/ios";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Fixes #11 

This adds a precompiled prefix header to the AssimpSceneKit lib code and updates the project settings.

To enable logging, uncomment `MY_DEBUG` in `AssimpSceneKit-Prefix.pch`.