### PR TITLE
Add framework target for iOS

### DIFF
--- a/AssimpKit/AssimpKit.xcworkspace/contents.xcworkspacedata
+++ b/AssimpKit/AssimpKit.xcworkspace/contents.xcworkspacedata
@@ -1,6 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Workspace
    version = "1.0">
+   <Group
+      location = "container:"
+      name = "Library">
+      <Group
+         location = "group:Code"
+         name = "Code">
+         <Group
+            location = "group:Model"
+            name = "Model">
+            <FileRef
+               location = "group:AssimpImporter.h">
+            </FileRef>
+            <FileRef
+               location = "group:AssimpImporter.m">
+            </FileRef>
+            <FileRef
+               location = "group:AssimpSceneKit-Prefix.pch">
+            </FileRef>
+            <FileRef
+               location = "group:SCNAssimpAnimation.h">
+            </FileRef>
+            <FileRef
+               location = "group:SCNAssimpAnimation.m">
+            </FileRef>
+            <FileRef
+               location = "group:SCNAssimpScene.h">
+            </FileRef>
+            <FileRef
+               location = "group:SCNAssimpScene.m">
+            </FileRef>
+            <FileRef
+               location = "group:SCNScene+AssimpImport.h">
+            </FileRef>
+            <FileRef
+               location = "group:SCNScene+AssimpImport.m">
+            </FileRef>
+            <Group
+               location = "group:Tests"
+               name = "Tests">
+               <FileRef
+                  location = "group:AssimpImporterTests.m">
+               </FileRef>
+               <FileRef
+                  location = "group:ModelLog.h">
+               </FileRef>
+               <FileRef
+                  location = "group:ModelLog.m">
+               </FileRef>
+            </Group>
+         </Group>
+      </Group>
+   </Group>
    <FileRef
       location = "group:iOS-Example/iOS-Example.xcodeproj">
    </FileRef>

--- a/AssimpKit/OSX-Example/AssimpKit/Info.plist
+++ b/AssimpKit/OSX-Example/AssimpKit/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2016 Ison Apps. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/AssimpKit/OSX-Example/OSX-Example.xcodeproj/project.pbxproj
+++ b/AssimpKit/OSX-Example/OSX-Example.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		779DF17B1DDEDD3300DED366 /* SCNAssimpScene.m in Sources */ = {isa = PBXBuildFile; fileRef = 779DF1721DDEDD3300DED366 /* SCNAssimpScene.m */; };
 		779DF17C1DDEDD3300DED366 /* SCNScene+AssimpImport.h in Headers */ = {isa = PBXBuildFile; fileRef = 779DF1731DDEDD3300DED366 /* SCNScene+AssimpImport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		779DF17D1DDEDD3300DED366 /* SCNScene+AssimpImport.m in Sources */ = {isa = PBXBuildFile; fileRef = 779DF1741DDEDD3300DED366 /* SCNScene+AssimpImport.m */; };
+		779DF17E1DDEE58900DED366 /* AssimpKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 779DF15F1DDEDCCB00DED366 /* AssimpKit.framework */; };
 		77CDAA571DD715C300B7E342 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAA561DD715C300B7E342 /* AppDelegate.m */; };
 		77CDAA5A1DD715C300B7E342 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAA591DD715C300B7E342 /* main.m */; };
 		77CDAA711DD715FE00B7E342 /* art.scnassets in Resources */ = {isa = PBXBuildFile; fileRef = 77CDAA661DD715FE00B7E342 /* art.scnassets */; };
@@ -27,18 +28,8 @@
 		77CDAA761DD715FE00B7E342 /* spider.obj in Resources */ = {isa = PBXBuildFile; fileRef = 77CDAA6F1DD715FE00B7E342 /* spider.obj */; };
 		77CDAA771DD715FE00B7E342 /* SpiderTex.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 77CDAA701DD715FE00B7E342 /* SpiderTex.jpg */; };
 		77CDAA7A1DD716F100B7E342 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 77CDAA781DD716F100B7E342 /* MainMenu.xib */; };
-		77CDAACF1DD71EF600B7E342 /* AssimpImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 77CDAAC71DD71EF600B7E342 /* AssimpImporter.h */; };
-		77CDAAD01DD71EF600B7E342 /* AssimpImporter.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAAC81DD71EF600B7E342 /* AssimpImporter.m */; };
-		77CDAAD11DD71EF600B7E342 /* SCNAssimpAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 77CDAAC91DD71EF600B7E342 /* SCNAssimpAnimation.h */; };
-		77CDAAD21DD71EF600B7E342 /* SCNAssimpAnimation.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAACA1DD71EF600B7E342 /* SCNAssimpAnimation.m */; };
-		77CDAAD31DD71EF600B7E342 /* SCNAssimpScene.h in Headers */ = {isa = PBXBuildFile; fileRef = 77CDAACB1DD71EF600B7E342 /* SCNAssimpScene.h */; };
-		77CDAAD41DD71EF600B7E342 /* SCNAssimpScene.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAACC1DD71EF600B7E342 /* SCNAssimpScene.m */; };
-		77CDAAD51DD71EF600B7E342 /* SCNScene+AssimpImport.h in Headers */ = {isa = PBXBuildFile; fileRef = 77CDAACD1DD71EF600B7E342 /* SCNScene+AssimpImport.h */; };
-		77CDAAD61DD71EF600B7E342 /* SCNScene+AssimpImport.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAACE1DD71EF600B7E342 /* SCNScene+AssimpImport.m */; };
-		77CDAB1C1DD733E800B7E342 /* libAssimpSceneKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 77CDAA861DD717FD00B7E342 /* libAssimpSceneKit.a */; };
 		77CDAB251DD7341000B7E342 /* AssimpImporterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAB221DD7341000B7E342 /* AssimpImporterTests.m */; };
 		77CDAB261DD7341000B7E342 /* ModelLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAB241DD7341000B7E342 /* ModelLog.m */; };
-		77CDAB2A1DD7351B00B7E342 /* libassimp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 77CDAAC51DD71D0C00B7E342 /* libassimp.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -48,20 +39,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 779DF15E1DDEDCCB00DED366;
 			remoteInfo = AssimpKit;
-		};
-		77CDAABE1DD71B0300B7E342 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 77CDAA4A1DD715C300B7E342 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 77CDAA851DD717FD00B7E342;
-			remoteInfo = AssimpSceneKit;
-		};
-		77CDAB1D1DD733E800B7E342 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 77CDAA4A1DD715C300B7E342 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 77CDAA851DD717FD00B7E342;
-			remoteInfo = AssimpSceneKit;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -114,16 +91,7 @@
 		77CDAA701DD715FE00B7E342 /* SpiderTex.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = SpiderTex.jpg; sourceTree = "<group>"; };
 		77CDAA791DD716F100B7E342 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		77CDAA801DD7172F00B7E342 /* libassimp.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libassimp.a; path = ../Assimp/lib/osx/libassimp.a; sourceTree = "<group>"; };
-		77CDAA861DD717FD00B7E342 /* libAssimpSceneKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAssimpSceneKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		77CDAAC51DD71D0C00B7E342 /* libassimp.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libassimp.a; path = ../Assimp/lib/osx/libassimp.a; sourceTree = "<group>"; };
-		77CDAAC71DD71EF600B7E342 /* AssimpImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AssimpImporter.h; path = ../../Code/Model/AssimpImporter.h; sourceTree = "<group>"; };
-		77CDAAC81DD71EF600B7E342 /* AssimpImporter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AssimpImporter.m; path = ../../Code/Model/AssimpImporter.m; sourceTree = "<group>"; };
-		77CDAAC91DD71EF600B7E342 /* SCNAssimpAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SCNAssimpAnimation.h; path = ../../Code/Model/SCNAssimpAnimation.h; sourceTree = "<group>"; };
-		77CDAACA1DD71EF600B7E342 /* SCNAssimpAnimation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SCNAssimpAnimation.m; path = ../../Code/Model/SCNAssimpAnimation.m; sourceTree = "<group>"; };
-		77CDAACB1DD71EF600B7E342 /* SCNAssimpScene.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SCNAssimpScene.h; path = ../../Code/Model/SCNAssimpScene.h; sourceTree = "<group>"; };
-		77CDAACC1DD71EF600B7E342 /* SCNAssimpScene.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SCNAssimpScene.m; path = ../../Code/Model/SCNAssimpScene.m; sourceTree = "<group>"; };
-		77CDAACD1DD71EF600B7E342 /* SCNScene+AssimpImport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SCNScene+AssimpImport.h"; path = "../../Code/Model/SCNScene+AssimpImport.h"; sourceTree = "<group>"; };
-		77CDAACE1DD71EF600B7E342 /* SCNScene+AssimpImport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "SCNScene+AssimpImport.m"; path = "../../Code/Model/SCNScene+AssimpImport.m"; sourceTree = "<group>"; };
 		77CDAB171DD733E800B7E342 /* AssimpSceneKit_LogicTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AssimpSceneKit_LogicTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		77CDAB1B1DD733E800B7E342 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		77CDAB221DD7341000B7E342 /* AssimpImporterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AssimpImporterTests.m; path = ../../Code/Model/Tests/AssimpImporterTests.m; sourceTree = "<group>"; };
@@ -148,19 +116,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		77CDAA831DD717FD00B7E342 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		77CDAB141DD733E800B7E342 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				77CDAB1C1DD733E800B7E342 /* libAssimpSceneKit.a in Frameworks */,
-				77CDAB2A1DD7351B00B7E342 /* libassimp.a in Frameworks */,
+				779DF17E1DDEE58900DED366 /* AssimpKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -189,7 +149,6 @@
 			children = (
 				77CDAAC51DD71D0C00B7E342 /* libassimp.a */,
 				77CDAA541DD715C300B7E342 /* OSX-Example */,
-				77CDAA871DD717FD00B7E342 /* AssimpSceneKit */,
 				77CDAB181DD733E800B7E342 /* AssimpSceneKit_LogicTests */,
 				779DF1601DDEDCCB00DED366 /* AssimpKit */,
 				77CDAA531DD715C300B7E342 /* Products */,
@@ -201,7 +160,6 @@
 			isa = PBXGroup;
 			children = (
 				77CDAA521DD715C300B7E342 /* OSX-Example.app */,
-				77CDAA861DD717FD00B7E342 /* libAssimpSceneKit.a */,
 				77CDAB171DD733E800B7E342 /* AssimpSceneKit_LogicTests.xctest */,
 				779DF15F1DDEDCCB00DED366 /* AssimpKit.framework */,
 			);
@@ -243,21 +201,6 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		77CDAA871DD717FD00B7E342 /* AssimpSceneKit */ = {
-			isa = PBXGroup;
-			children = (
-				77CDAAC71DD71EF600B7E342 /* AssimpImporter.h */,
-				77CDAAC81DD71EF600B7E342 /* AssimpImporter.m */,
-				77CDAAC91DD71EF600B7E342 /* SCNAssimpAnimation.h */,
-				77CDAACA1DD71EF600B7E342 /* SCNAssimpAnimation.m */,
-				77CDAACB1DD71EF600B7E342 /* SCNAssimpScene.h */,
-				77CDAACC1DD71EF600B7E342 /* SCNAssimpScene.m */,
-				77CDAACD1DD71EF600B7E342 /* SCNScene+AssimpImport.h */,
-				77CDAACE1DD71EF600B7E342 /* SCNScene+AssimpImport.m */,
-			);
-			path = AssimpSceneKit;
-			sourceTree = "<group>";
-		};
 		77CDAB181DD733E800B7E342 /* AssimpSceneKit_LogicTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -281,17 +224,6 @@
 				779DF1781DDEDD3300DED366 /* SCNAssimpAnimation.h in Headers */,
 				779DF1751DDEDD3300DED366 /* AssimpImporter.h in Headers */,
 				779DF17C1DDEDD3300DED366 /* SCNScene+AssimpImport.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		77CDAA841DD717FD00B7E342 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				77CDAACF1DD71EF600B7E342 /* AssimpImporter.h in Headers */,
-				77CDAAD11DD71EF600B7E342 /* SCNAssimpAnimation.h in Headers */,
-				77CDAAD31DD71EF600B7E342 /* SCNAssimpScene.h in Headers */,
-				77CDAAD51DD71EF600B7E342 /* SCNScene+AssimpImport.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -329,30 +261,12 @@
 			buildRules = (
 			);
 			dependencies = (
-				77CDAABF1DD71B0300B7E342 /* PBXTargetDependency */,
 				779DF1651DDEDCCB00DED366 /* PBXTargetDependency */,
 			);
 			name = "OSX-Example";
 			productName = "OSX-Example";
 			productReference = 77CDAA521DD715C300B7E342 /* OSX-Example.app */;
 			productType = "com.apple.product-type.application";
-		};
-		77CDAA851DD717FD00B7E342 /* AssimpSceneKit */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 77CDAA8C1DD717FE00B7E342 /* Build configuration list for PBXNativeTarget "AssimpSceneKit" */;
-			buildPhases = (
-				77CDAA821DD717FD00B7E342 /* Sources */,
-				77CDAA831DD717FD00B7E342 /* Frameworks */,
-				77CDAA841DD717FD00B7E342 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = AssimpSceneKit;
-			productName = AssimpSceneKit;
-			productReference = 77CDAA861DD717FD00B7E342 /* libAssimpSceneKit.a */;
-			productType = "com.apple.product-type.library.static";
 		};
 		77CDAB161DD733E800B7E342 /* AssimpSceneKit_LogicTests */ = {
 			isa = PBXNativeTarget;
@@ -365,7 +279,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				77CDAB1E1DD733E800B7E342 /* PBXTargetDependency */,
 			);
 			name = AssimpSceneKit_LogicTests;
 			productName = AssimpSceneKit_LogicTests;
@@ -391,11 +304,6 @@
 						DevelopmentTeam = PRJ5CHFB5D;
 						ProvisioningStyle = Automatic;
 					};
-					77CDAA851DD717FD00B7E342 = {
-						CreatedOnToolsVersion = 8.1;
-						DevelopmentTeam = PRJ5CHFB5D;
-						ProvisioningStyle = Automatic;
-					};
 					77CDAB161DD733E800B7E342 = {
 						CreatedOnToolsVersion = 8.1;
 						DevelopmentTeam = PRJ5CHFB5D;
@@ -417,7 +325,6 @@
 			projectRoot = "";
 			targets = (
 				77CDAA511DD715C300B7E342 /* OSX-Example */,
-				77CDAA851DD717FD00B7E342 /* AssimpSceneKit */,
 				77CDAB161DD733E800B7E342 /* AssimpSceneKit_LogicTests */,
 				779DF15E1DDEDCCB00DED366 /* AssimpKit */,
 			);
@@ -475,17 +382,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		77CDAA821DD717FD00B7E342 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				77CDAAD41DD71EF600B7E342 /* SCNAssimpScene.m in Sources */,
-				77CDAAD21DD71EF600B7E342 /* SCNAssimpAnimation.m in Sources */,
-				77CDAAD01DD71EF600B7E342 /* AssimpImporter.m in Sources */,
-				77CDAAD61DD71EF600B7E342 /* SCNScene+AssimpImport.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		77CDAB131DD733E800B7E342 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -502,16 +398,6 @@
 			isa = PBXTargetDependency;
 			target = 779DF15E1DDEDCCB00DED366 /* AssimpKit */;
 			targetProxy = 779DF1641DDEDCCB00DED366 /* PBXContainerItemProxy */;
-		};
-		77CDAABF1DD71B0300B7E342 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 77CDAA851DD717FD00B7E342 /* AssimpSceneKit */;
-			targetProxy = 77CDAABE1DD71B0300B7E342 /* PBXContainerItemProxy */;
-		};
-		77CDAB1E1DD733E800B7E342 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 77CDAA851DD717FD00B7E342 /* AssimpSceneKit */;
-			targetProxy = 77CDAB1D1DD733E800B7E342 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -712,38 +598,6 @@
 			};
 			name = Release;
 		};
-		77CDAA8D1DD717FE00B7E342 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				DEVELOPMENT_TEAM = PRJ5CHFB5D;
-				EXECUTABLE_PREFIX = lib;
-				FRAMEWORK_SEARCH_PATHS = "";
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/../Code/Model/AssimpSceneKit-Prefix.pch";
-				HEADER_SEARCH_PATHS = "";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/osx";
-				OTHER_LDFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				USER_HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/include";
-			};
-			name = Debug;
-		};
-		77CDAA8E1DD717FE00B7E342 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				DEVELOPMENT_TEAM = PRJ5CHFB5D;
-				EXECUTABLE_PREFIX = lib;
-				FRAMEWORK_SEARCH_PATHS = "";
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/../Code/Model/AssimpSceneKit-Prefix.pch";
-				HEADER_SEARCH_PATHS = "";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/osx";
-				OTHER_LDFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				USER_HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/include";
-			};
-			name = Release;
-		};
 		77CDAB201DD733E800B7E342 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -759,7 +613,7 @@
 				);
 				INFOPLIST_FILE = AssimpSceneKit_LogicTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/osx";
+				LIBRARY_SEARCH_PATHS = "";
 				OTHER_LDFLAGS = (
 					"-lz",
 					"-lstdc++",
@@ -780,7 +634,7 @@
 				GCC_PREFIX_HEADER = "";
 				INFOPLIST_FILE = AssimpSceneKit_LogicTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/osx";
+				LIBRARY_SEARCH_PATHS = "";
 				OTHER_LDFLAGS = (
 					"-lz",
 					"-lstdc++",
@@ -816,15 +670,6 @@
 			buildConfigurations = (
 				77CDAA641DD715C300B7E342 /* Debug */,
 				77CDAA651DD715C300B7E342 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		77CDAA8C1DD717FE00B7E342 /* Build configuration list for PBXNativeTarget "AssimpSceneKit" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				77CDAA8D1DD717FE00B7E342 /* Debug */,
-				77CDAA8E1DD717FE00B7E342 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/AssimpKit/OSX-Example/OSX-Example.xcodeproj/project.pbxproj
+++ b/AssimpKit/OSX-Example/OSX-Example.xcodeproj/project.pbxproj
@@ -7,6 +7,18 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		779DF1661DDEDCCB00DED366 /* AssimpKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 779DF15F1DDEDCCB00DED366 /* AssimpKit.framework */; };
+		779DF1671DDEDCCB00DED366 /* AssimpKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 779DF15F1DDEDCCB00DED366 /* AssimpKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		779DF16B1DDEDCDC00DED366 /* libassimp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 77CDAAC51DD71D0C00B7E342 /* libassimp.a */; };
+		779DF1751DDEDD3300DED366 /* AssimpImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 779DF16C1DDEDD3300DED366 /* AssimpImporter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		779DF1761DDEDD3300DED366 /* AssimpImporter.m in Sources */ = {isa = PBXBuildFile; fileRef = 779DF16D1DDEDD3300DED366 /* AssimpImporter.m */; };
+		779DF1771DDEDD3300DED366 /* AssimpSceneKit-Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = 779DF16E1DDEDD3300DED366 /* AssimpSceneKit-Prefix.pch */; settings = {ATTRIBUTES = (Public, ); }; };
+		779DF1781DDEDD3300DED366 /* SCNAssimpAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 779DF16F1DDEDD3300DED366 /* SCNAssimpAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		779DF1791DDEDD3300DED366 /* SCNAssimpAnimation.m in Sources */ = {isa = PBXBuildFile; fileRef = 779DF1701DDEDD3300DED366 /* SCNAssimpAnimation.m */; };
+		779DF17A1DDEDD3300DED366 /* SCNAssimpScene.h in Headers */ = {isa = PBXBuildFile; fileRef = 779DF1711DDEDD3300DED366 /* SCNAssimpScene.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		779DF17B1DDEDD3300DED366 /* SCNAssimpScene.m in Sources */ = {isa = PBXBuildFile; fileRef = 779DF1721DDEDD3300DED366 /* SCNAssimpScene.m */; };
+		779DF17C1DDEDD3300DED366 /* SCNScene+AssimpImport.h in Headers */ = {isa = PBXBuildFile; fileRef = 779DF1731DDEDD3300DED366 /* SCNScene+AssimpImport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		779DF17D1DDEDD3300DED366 /* SCNScene+AssimpImport.m in Sources */ = {isa = PBXBuildFile; fileRef = 779DF1741DDEDD3300DED366 /* SCNScene+AssimpImport.m */; };
 		77CDAA571DD715C300B7E342 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAA561DD715C300B7E342 /* AppDelegate.m */; };
 		77CDAA5A1DD715C300B7E342 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAA591DD715C300B7E342 /* main.m */; };
 		77CDAA711DD715FE00B7E342 /* art.scnassets in Resources */ = {isa = PBXBuildFile; fileRef = 77CDAA661DD715FE00B7E342 /* art.scnassets */; };
@@ -23,8 +35,6 @@
 		77CDAAD41DD71EF600B7E342 /* SCNAssimpScene.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAACC1DD71EF600B7E342 /* SCNAssimpScene.m */; };
 		77CDAAD51DD71EF600B7E342 /* SCNScene+AssimpImport.h in Headers */ = {isa = PBXBuildFile; fileRef = 77CDAACD1DD71EF600B7E342 /* SCNScene+AssimpImport.h */; };
 		77CDAAD61DD71EF600B7E342 /* SCNScene+AssimpImport.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAACE1DD71EF600B7E342 /* SCNScene+AssimpImport.m */; };
-		77CDAADC1DD71F3000B7E342 /* libAssimpSceneKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 77CDAA861DD717FD00B7E342 /* libAssimpSceneKit.a */; };
-		77CDAADD1DD7258700B7E342 /* libassimp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 77CDAAC51DD71D0C00B7E342 /* libassimp.a */; };
 		77CDAB1C1DD733E800B7E342 /* libAssimpSceneKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 77CDAA861DD717FD00B7E342 /* libAssimpSceneKit.a */; };
 		77CDAB251DD7341000B7E342 /* AssimpImporterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAB221DD7341000B7E342 /* AssimpImporterTests.m */; };
 		77CDAB261DD7341000B7E342 /* ModelLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAB241DD7341000B7E342 /* ModelLog.m */; };
@@ -32,6 +42,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		779DF1641DDEDCCB00DED366 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 77CDAA4A1DD715C300B7E342 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 779DF15E1DDEDCCB00DED366;
+			remoteInfo = AssimpKit;
+		};
 		77CDAABE1DD71B0300B7E342 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 77CDAA4A1DD715C300B7E342 /* Project object */;
@@ -55,6 +72,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				779DF1671DDEDCCB00DED366 /* AssimpKit.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -71,6 +89,17 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		779DF15F1DDEDCCB00DED366 /* AssimpKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AssimpKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		779DF1621DDEDCCB00DED366 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		779DF16C1DDEDD3300DED366 /* AssimpImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AssimpImporter.h; path = ../../Code/Model/AssimpImporter.h; sourceTree = "<group>"; };
+		779DF16D1DDEDD3300DED366 /* AssimpImporter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AssimpImporter.m; path = ../../Code/Model/AssimpImporter.m; sourceTree = "<group>"; };
+		779DF16E1DDEDD3300DED366 /* AssimpSceneKit-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "AssimpSceneKit-Prefix.pch"; path = "../../Code/Model/AssimpSceneKit-Prefix.pch"; sourceTree = "<group>"; };
+		779DF16F1DDEDD3300DED366 /* SCNAssimpAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SCNAssimpAnimation.h; path = ../../Code/Model/SCNAssimpAnimation.h; sourceTree = "<group>"; };
+		779DF1701DDEDD3300DED366 /* SCNAssimpAnimation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SCNAssimpAnimation.m; path = ../../Code/Model/SCNAssimpAnimation.m; sourceTree = "<group>"; };
+		779DF1711DDEDD3300DED366 /* SCNAssimpScene.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SCNAssimpScene.h; path = ../../Code/Model/SCNAssimpScene.h; sourceTree = "<group>"; };
+		779DF1721DDEDD3300DED366 /* SCNAssimpScene.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SCNAssimpScene.m; path = ../../Code/Model/SCNAssimpScene.m; sourceTree = "<group>"; };
+		779DF1731DDEDD3300DED366 /* SCNScene+AssimpImport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SCNScene+AssimpImport.h"; path = "../../Code/Model/SCNScene+AssimpImport.h"; sourceTree = "<group>"; };
+		779DF1741DDEDD3300DED366 /* SCNScene+AssimpImport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "SCNScene+AssimpImport.m"; path = "../../Code/Model/SCNScene+AssimpImport.m"; sourceTree = "<group>"; };
 		77CDAA521DD715C300B7E342 /* OSX-Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "OSX-Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		77CDAA551DD715C300B7E342 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		77CDAA561DD715C300B7E342 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -103,12 +132,19 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		779DF15B1DDEDCCB00DED366 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				779DF16B1DDEDCDC00DED366 /* libassimp.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		77CDAA4F1DD715C300B7E342 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				77CDAADC1DD71F3000B7E342 /* libAssimpSceneKit.a in Frameworks */,
-				77CDAADD1DD7258700B7E342 /* libassimp.a in Frameworks */,
+				779DF1661DDEDCCB00DED366 /* AssimpKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -131,6 +167,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		779DF1601DDEDCCB00DED366 /* AssimpKit */ = {
+			isa = PBXGroup;
+			children = (
+				779DF16C1DDEDD3300DED366 /* AssimpImporter.h */,
+				779DF16D1DDEDD3300DED366 /* AssimpImporter.m */,
+				779DF16E1DDEDD3300DED366 /* AssimpSceneKit-Prefix.pch */,
+				779DF16F1DDEDD3300DED366 /* SCNAssimpAnimation.h */,
+				779DF1701DDEDD3300DED366 /* SCNAssimpAnimation.m */,
+				779DF1711DDEDD3300DED366 /* SCNAssimpScene.h */,
+				779DF1721DDEDD3300DED366 /* SCNAssimpScene.m */,
+				779DF1731DDEDD3300DED366 /* SCNScene+AssimpImport.h */,
+				779DF1741DDEDD3300DED366 /* SCNScene+AssimpImport.m */,
+				779DF1621DDEDCCB00DED366 /* Info.plist */,
+			);
+			path = AssimpKit;
+			sourceTree = "<group>";
+		};
 		77CDAA491DD715C300B7E342 = {
 			isa = PBXGroup;
 			children = (
@@ -138,6 +191,7 @@
 				77CDAA541DD715C300B7E342 /* OSX-Example */,
 				77CDAA871DD717FD00B7E342 /* AssimpSceneKit */,
 				77CDAB181DD733E800B7E342 /* AssimpSceneKit_LogicTests */,
+				779DF1601DDEDCCB00DED366 /* AssimpKit */,
 				77CDAA531DD715C300B7E342 /* Products */,
 				77CDAA7F1DD7172F00B7E342 /* Frameworks */,
 			);
@@ -149,6 +203,7 @@
 				77CDAA521DD715C300B7E342 /* OSX-Example.app */,
 				77CDAA861DD717FD00B7E342 /* libAssimpSceneKit.a */,
 				77CDAB171DD733E800B7E342 /* AssimpSceneKit_LogicTests.xctest */,
+				779DF15F1DDEDCCB00DED366 /* AssimpKit.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -217,6 +272,18 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		779DF15C1DDEDCCB00DED366 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				779DF1771DDEDD3300DED366 /* AssimpSceneKit-Prefix.pch in Headers */,
+				779DF17A1DDEDD3300DED366 /* SCNAssimpScene.h in Headers */,
+				779DF1781DDEDD3300DED366 /* SCNAssimpAnimation.h in Headers */,
+				779DF1751DDEDD3300DED366 /* AssimpImporter.h in Headers */,
+				779DF17C1DDEDD3300DED366 /* SCNScene+AssimpImport.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		77CDAA841DD717FD00B7E342 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -231,6 +298,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		779DF15E1DDEDCCB00DED366 /* AssimpKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 779DF16A1DDEDCCB00DED366 /* Build configuration list for PBXNativeTarget "AssimpKit" */;
+			buildPhases = (
+				779DF15A1DDEDCCB00DED366 /* Sources */,
+				779DF15B1DDEDCCB00DED366 /* Frameworks */,
+				779DF15C1DDEDCCB00DED366 /* Headers */,
+				779DF15D1DDEDCCB00DED366 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AssimpKit;
+			productName = AssimpKit;
+			productReference = 779DF15F1DDEDCCB00DED366 /* AssimpKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		77CDAA511DD715C300B7E342 /* OSX-Example */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 77CDAA631DD715C300B7E342 /* Build configuration list for PBXNativeTarget "OSX-Example" */;
@@ -245,6 +330,7 @@
 			);
 			dependencies = (
 				77CDAABF1DD71B0300B7E342 /* PBXTargetDependency */,
+				779DF1651DDEDCCB00DED366 /* PBXTargetDependency */,
 			);
 			name = "OSX-Example";
 			productName = "OSX-Example";
@@ -295,6 +381,11 @@
 				LastUpgradeCheck = 0810;
 				ORGANIZATIONNAME = "Ison Apps";
 				TargetAttributes = {
+					779DF15E1DDEDCCB00DED366 = {
+						CreatedOnToolsVersion = 8.1;
+						DevelopmentTeam = PRJ5CHFB5D;
+						ProvisioningStyle = Automatic;
+					};
 					77CDAA511DD715C300B7E342 = {
 						CreatedOnToolsVersion = 8.1;
 						DevelopmentTeam = PRJ5CHFB5D;
@@ -328,11 +419,19 @@
 				77CDAA511DD715C300B7E342 /* OSX-Example */,
 				77CDAA851DD717FD00B7E342 /* AssimpSceneKit */,
 				77CDAB161DD733E800B7E342 /* AssimpSceneKit_LogicTests */,
+				779DF15E1DDEDCCB00DED366 /* AssimpKit */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		779DF15D1DDEDCCB00DED366 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		77CDAA501DD715C300B7E342 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -354,6 +453,17 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		779DF15A1DDEDCCB00DED366 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				779DF17B1DDEDD3300DED366 /* SCNAssimpScene.m in Sources */,
+				779DF1791DDEDD3300DED366 /* SCNAssimpAnimation.m in Sources */,
+				779DF1761DDEDD3300DED366 /* AssimpImporter.m in Sources */,
+				779DF17D1DDEDD3300DED366 /* SCNScene+AssimpImport.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		77CDAA4E1DD715C300B7E342 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -388,6 +498,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		779DF1651DDEDCCB00DED366 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 779DF15E1DDEDCCB00DED366 /* AssimpKit */;
+			targetProxy = 779DF1641DDEDCCB00DED366 /* PBXContainerItemProxy */;
+		};
 		77CDAABF1DD71B0300B7E342 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 77CDAA851DD717FD00B7E342 /* AssimpSceneKit */;
@@ -412,6 +527,72 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		779DF1681DDEDCCB00DED366 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = PRJ5CHFB5D;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/../Code/Model/AssimpSceneKit-Prefix.pch";
+				INFOPLIST_FILE = AssimpKit/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/osx";
+				OTHER_LDFLAGS = (
+					"-lz",
+					"-lstdc++",
+					"-ObjC",
+					"-all_load",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.isonapps.AssimpKit;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				USER_HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/include";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		779DF1691DDEDCCB00DED366 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = PRJ5CHFB5D;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/../Code/Model/AssimpSceneKit-Prefix.pch";
+				INFOPLIST_FILE = AssimpKit/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/osx";
+				OTHER_LDFLAGS = (
+					"-lz",
+					"-lstdc++",
+					"-ObjC",
+					"-all_load",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.isonapps.AssimpKit;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				USER_HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/include";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		77CDAA611DD715C300B7E342 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -504,22 +685,14 @@
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = PRJ5CHFB5D;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/../Carthage/Build/Mac",
-					"$(DEVELOPER_DIR)/Library/Frameworks",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(DEVELOPER_DIR)/Library/Frameworks";
 				INFOPLIST_FILE = "OSX-Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/osx";
-				OTHER_LDFLAGS = (
-					"-ObjC",
-					"-all_load",
-					"-lz",
-					"-lstdc++",
-				);
+				LIBRARY_SEARCH_PATHS = "";
+				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.isonapps.OSX-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				USER_HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/include";
+				USER_HEADER_SEARCH_PATHS = "";
 			};
 			name = Debug;
 		};
@@ -528,22 +701,14 @@
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = PRJ5CHFB5D;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/../Carthage/Build/Mac",
-					"$(DEVELOPER_DIR)/Library/Frameworks",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(DEVELOPER_DIR)/Library/Frameworks";
 				INFOPLIST_FILE = "OSX-Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/osx";
-				OTHER_LDFLAGS = (
-					"-ObjC",
-					"-all_load",
-					"-lz",
-					"-lstdc++",
-				);
+				LIBRARY_SEARCH_PATHS = "";
+				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.isonapps.OSX-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				USER_HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/include";
+				USER_HEADER_SEARCH_PATHS = "";
 			};
 			name = Release;
 		};
@@ -629,6 +794,14 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		779DF16A1DDEDCCB00DED366 /* Build configuration list for PBXNativeTarget "AssimpKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				779DF1681DDEDCCB00DED366 /* Debug */,
+				779DF1691DDEDCCB00DED366 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		77CDAA4D1DD715C300B7E342 /* Build configuration list for PBXProject "OSX-Example" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/AssimpKit/OSX-Example/OSX-Example.xcodeproj/xcshareddata/xcschemes/AssimpKit.xcscheme
+++ b/AssimpKit/OSX-Example/OSX-Example.xcodeproj/xcshareddata/xcschemes/AssimpKit.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0810"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "779DF15E1DDEDCCB00DED366"
+               BuildableName = "AssimpKit.framework"
+               BlueprintName = "AssimpKit"
+               ReferencedContainer = "container:OSX-Example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "779DF15E1DDEDCCB00DED366"
+            BuildableName = "AssimpKit.framework"
+            BlueprintName = "AssimpKit"
+            ReferencedContainer = "container:OSX-Example.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "779DF15E1DDEDCCB00DED366"
+            BuildableName = "AssimpKit.framework"
+            BlueprintName = "AssimpKit"
+            ReferencedContainer = "container:OSX-Example.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/AssimpKit/iOS-Example/AssimpKit/Info.plist
+++ b/AssimpKit/iOS-Example/AssimpKit/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/AssimpKit/iOS-Example/iOS-Example.xcodeproj/project.pbxproj
+++ b/AssimpKit/iOS-Example/iOS-Example.xcodeproj/project.pbxproj
@@ -7,6 +7,19 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		779DF14B1DDED89400DED366 /* AssimpImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 779DF1421DDED89400DED366 /* AssimpImporter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		779DF14C1DDED89400DED366 /* AssimpImporter.m in Sources */ = {isa = PBXBuildFile; fileRef = 779DF1431DDED89400DED366 /* AssimpImporter.m */; };
+		779DF14D1DDED89400DED366 /* AssimpSceneKit-Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = 779DF1441DDED89400DED366 /* AssimpSceneKit-Prefix.pch */; settings = {ATTRIBUTES = (Public, ); }; };
+		779DF14E1DDED89400DED366 /* SCNAssimpAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 779DF1451DDED89400DED366 /* SCNAssimpAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		779DF14F1DDED89400DED366 /* SCNAssimpAnimation.m in Sources */ = {isa = PBXBuildFile; fileRef = 779DF1461DDED89400DED366 /* SCNAssimpAnimation.m */; };
+		779DF1501DDED89400DED366 /* SCNAssimpScene.h in Headers */ = {isa = PBXBuildFile; fileRef = 779DF1471DDED89400DED366 /* SCNAssimpScene.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		779DF1511DDED89400DED366 /* SCNAssimpScene.m in Sources */ = {isa = PBXBuildFile; fileRef = 779DF1481DDED89400DED366 /* SCNAssimpScene.m */; };
+		779DF1521DDED89400DED366 /* SCNScene+AssimpImport.h in Headers */ = {isa = PBXBuildFile; fileRef = 779DF1491DDED89400DED366 /* SCNScene+AssimpImport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		779DF1531DDED89400DED366 /* SCNScene+AssimpImport.m in Sources */ = {isa = PBXBuildFile; fileRef = 779DF14A1DDED89400DED366 /* SCNScene+AssimpImport.m */; };
+		779DF1541DDED8D000DED366 /* AssimpKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77BE97D01DDE11B30056D354 /* AssimpKit.framework */; };
+		779DF1551DDED8D000DED366 /* AssimpKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 77BE97D01DDE11B30056D354 /* AssimpKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		779DF1591DDED93000DED366 /* AssimpKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77BE97D01DDE11B30056D354 /* AssimpKit.framework */; };
+		77BE97F71DDE122A0056D354 /* libassimp-fat.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 77CDAB701DD743B100B7E342 /* libassimp-fat.a */; };
 		77CDAB3F1DD7421500B7E342 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAB3E1DD7421500B7E342 /* main.m */; };
 		77CDAB421DD7421500B7E342 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAB411DD7421500B7E342 /* AppDelegate.m */; };
 		77CDAB441DD7421500B7E342 /* art.scnassets in Resources */ = {isa = PBXBuildFile; fileRef = 77CDAB431DD7421500B7E342 /* art.scnassets */; };
@@ -18,15 +31,18 @@
 		77CDAB6C1DD7429900B7E342 /* SCNAssimpAnimation.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAB661DD7429900B7E342 /* SCNAssimpAnimation.m */; };
 		77CDAB6D1DD7429900B7E342 /* SCNAssimpScene.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAB681DD7429900B7E342 /* SCNAssimpScene.m */; };
 		77CDAB6E1DD7429900B7E342 /* SCNScene+AssimpImport.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAB6A1DD7429900B7E342 /* SCNScene+AssimpImport.m */; };
-		77CDAB711DD743B100B7E342 /* libassimp-fat.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 77CDAB701DD743B100B7E342 /* libassimp-fat.a */; };
-		77CDAB741DD7447B00B7E342 /* libAssimpSceneKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 77CDAB5A1DD7428900B7E342 /* libAssimpSceneKit.a */; };
-		77CDAB7E1DD745D800B7E342 /* libAssimpSceneKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 77CDAB5A1DD7428900B7E342 /* libAssimpSceneKit.a */; };
 		77CDAB881DD745EA00B7E342 /* ModelLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAB861DD745EA00B7E342 /* ModelLog.m */; };
-		77CDAB891DD7486800B7E342 /* libassimp-fat.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 77CDAB701DD743B100B7E342 /* libassimp-fat.a */; };
 		77CDAB8B1DD749CB00B7E342 /* AssimpImporterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAB8A1DD749CB00B7E342 /* AssimpImporterTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		779DF1561DDED8D000DED366 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 77CDAB321DD7421500B7E342 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 77BE97CF1DDE11B30056D354;
+			remoteInfo = AssimpKit;
+		};
 		77CDAB721DD7447600B7E342 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 77CDAB321DD7421500B7E342 /* Project object */;
@@ -44,6 +60,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		779DF1581DDED8D100DED366 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				779DF1551DDED8D000DED366 /* AssimpKit.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		77CDAB581DD7428900B7E342 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -56,6 +83,17 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		779DF1421DDED89400DED366 /* AssimpImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AssimpImporter.h; path = ../../Code/Model/AssimpImporter.h; sourceTree = "<group>"; };
+		779DF1431DDED89400DED366 /* AssimpImporter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AssimpImporter.m; path = ../../Code/Model/AssimpImporter.m; sourceTree = "<group>"; };
+		779DF1441DDED89400DED366 /* AssimpSceneKit-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "AssimpSceneKit-Prefix.pch"; path = "../../Code/Model/AssimpSceneKit-Prefix.pch"; sourceTree = "<group>"; };
+		779DF1451DDED89400DED366 /* SCNAssimpAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SCNAssimpAnimation.h; path = ../../Code/Model/SCNAssimpAnimation.h; sourceTree = "<group>"; };
+		779DF1461DDED89400DED366 /* SCNAssimpAnimation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SCNAssimpAnimation.m; path = ../../Code/Model/SCNAssimpAnimation.m; sourceTree = "<group>"; };
+		779DF1471DDED89400DED366 /* SCNAssimpScene.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SCNAssimpScene.h; path = ../../Code/Model/SCNAssimpScene.h; sourceTree = "<group>"; };
+		779DF1481DDED89400DED366 /* SCNAssimpScene.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SCNAssimpScene.m; path = ../../Code/Model/SCNAssimpScene.m; sourceTree = "<group>"; };
+		779DF1491DDED89400DED366 /* SCNScene+AssimpImport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SCNScene+AssimpImport.h"; path = "../../Code/Model/SCNScene+AssimpImport.h"; sourceTree = "<group>"; };
+		779DF14A1DDED89400DED366 /* SCNScene+AssimpImport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "SCNScene+AssimpImport.m"; path = "../../Code/Model/SCNScene+AssimpImport.m"; sourceTree = "<group>"; };
+		77BE97D01DDE11B30056D354 /* AssimpKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AssimpKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		77BE97D31DDE11B30056D354 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		77CDAB3A1DD7421500B7E342 /* iOS-Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "iOS-Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		77CDAB3E1DD7421500B7E342 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		77CDAB401DD7421500B7E342 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -85,12 +123,19 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		77BE97CC1DDE11B30056D354 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				77BE97F71DDE122A0056D354 /* libassimp-fat.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		77CDAB371DD7421500B7E342 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				77CDAB711DD743B100B7E342 /* libassimp-fat.a in Frameworks */,
-				77CDAB741DD7447B00B7E342 /* libAssimpSceneKit.a in Frameworks */,
+				779DF1541DDED8D000DED366 /* AssimpKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -105,20 +150,37 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				77CDAB7E1DD745D800B7E342 /* libAssimpSceneKit.a in Frameworks */,
-				77CDAB891DD7486800B7E342 /* libassimp-fat.a in Frameworks */,
+				779DF1591DDED93000DED366 /* AssimpKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		77BE97D11DDE11B30056D354 /* AssimpKit */ = {
+			isa = PBXGroup;
+			children = (
+				779DF1421DDED89400DED366 /* AssimpImporter.h */,
+				779DF1431DDED89400DED366 /* AssimpImporter.m */,
+				779DF1441DDED89400DED366 /* AssimpSceneKit-Prefix.pch */,
+				779DF1451DDED89400DED366 /* SCNAssimpAnimation.h */,
+				779DF1461DDED89400DED366 /* SCNAssimpAnimation.m */,
+				779DF1471DDED89400DED366 /* SCNAssimpScene.h */,
+				779DF1481DDED89400DED366 /* SCNAssimpScene.m */,
+				779DF1491DDED89400DED366 /* SCNScene+AssimpImport.h */,
+				779DF14A1DDED89400DED366 /* SCNScene+AssimpImport.m */,
+				77BE97D31DDE11B30056D354 /* Info.plist */,
+			);
+			path = AssimpKit;
+			sourceTree = "<group>";
+		};
 		77CDAB311DD7421500B7E342 = {
 			isa = PBXGroup;
 			children = (
 				77CDAB3C1DD7421500B7E342 /* iOS-Example */,
 				77CDAB5B1DD7428900B7E342 /* AssimpSceneKit */,
 				77CDAB7A1DD745D800B7E342 /* AssimpSceneKit_LogicTests */,
+				77BE97D11DDE11B30056D354 /* AssimpKit */,
 				77CDAB3B1DD7421500B7E342 /* Products */,
 				77CDAB6F1DD743B100B7E342 /* Frameworks */,
 			);
@@ -130,6 +192,7 @@
 				77CDAB3A1DD7421500B7E342 /* iOS-Example.app */,
 				77CDAB5A1DD7428900B7E342 /* libAssimpSceneKit.a */,
 				77CDAB791DD745D800B7E342 /* AssimpSceneKit_LogicTests.xctest */,
+				77BE97D01DDE11B30056D354 /* AssimpKit.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -195,7 +258,40 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		77BE97CD1DDE11B30056D354 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				779DF14D1DDED89400DED366 /* AssimpSceneKit-Prefix.pch in Headers */,
+				779DF14B1DDED89400DED366 /* AssimpImporter.h in Headers */,
+				779DF14E1DDED89400DED366 /* SCNAssimpAnimation.h in Headers */,
+				779DF1521DDED89400DED366 /* SCNScene+AssimpImport.h in Headers */,
+				779DF1501DDED89400DED366 /* SCNAssimpScene.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
+		77BE97CF1DDE11B30056D354 /* AssimpKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 77BE97DB1DDE11B30056D354 /* Build configuration list for PBXNativeTarget "AssimpKit" */;
+			buildPhases = (
+				77BE97CB1DDE11B30056D354 /* Sources */,
+				77BE97CC1DDE11B30056D354 /* Frameworks */,
+				77BE97CD1DDE11B30056D354 /* Headers */,
+				77BE97CE1DDE11B30056D354 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AssimpKit;
+			productName = AssimpKit;
+			productReference = 77BE97D01DDE11B30056D354 /* AssimpKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		77CDAB391DD7421500B7E342 /* iOS-Example */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 77CDAB531DD7421600B7E342 /* Build configuration list for PBXNativeTarget "iOS-Example" */;
@@ -203,11 +299,13 @@
 				77CDAB361DD7421500B7E342 /* Sources */,
 				77CDAB371DD7421500B7E342 /* Frameworks */,
 				77CDAB381DD7421500B7E342 /* Resources */,
+				779DF1581DDED8D100DED366 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				77CDAB731DD7447600B7E342 /* PBXTargetDependency */,
+				779DF1571DDED8D000DED366 /* PBXTargetDependency */,
 			);
 			name = "iOS-Example";
 			productName = "iOS-Example";
@@ -258,6 +356,11 @@
 				LastUpgradeCheck = 0810;
 				ORGANIZATIONNAME = "Ison Apps";
 				TargetAttributes = {
+					77BE97CF1DDE11B30056D354 = {
+						CreatedOnToolsVersion = 8.1;
+						DevelopmentTeam = PRJ5CHFB5D;
+						ProvisioningStyle = Automatic;
+					};
 					77CDAB391DD7421500B7E342 = {
 						CreatedOnToolsVersion = 8.1;
 						DevelopmentTeam = PRJ5CHFB5D;
@@ -291,11 +394,19 @@
 				77CDAB391DD7421500B7E342 /* iOS-Example */,
 				77CDAB591DD7428900B7E342 /* AssimpSceneKit */,
 				77CDAB781DD745D800B7E342 /* AssimpSceneKit_LogicTests */,
+				77BE97CF1DDE11B30056D354 /* AssimpKit */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		77BE97CE1DDE11B30056D354 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		77CDAB381DD7421500B7E342 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -317,6 +428,17 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		77BE97CB1DDE11B30056D354 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				779DF1511DDED89400DED366 /* SCNAssimpScene.m in Sources */,
+				779DF14F1DDED89400DED366 /* SCNAssimpAnimation.m in Sources */,
+				779DF14C1DDED89400DED366 /* AssimpImporter.m in Sources */,
+				779DF1531DDED89400DED366 /* SCNScene+AssimpImport.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		77CDAB361DD7421500B7E342 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -350,6 +472,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		779DF1571DDED8D000DED366 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 77BE97CF1DDE11B30056D354 /* AssimpKit */;
+			targetProxy = 779DF1561DDED8D000DED366 /* PBXContainerItemProxy */;
+		};
 		77CDAB731DD7447600B7E342 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 77CDAB591DD7428900B7E342 /* AssimpSceneKit */;
@@ -382,10 +509,82 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		77BE97D91DDE11B30056D354 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = PRJ5CHFB5D;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = NO;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/../Code/Model/AssimpSceneKit-Prefix.pch";
+				INFOPLIST_FILE = AssimpKit/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/ios";
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_LDFLAGS = (
+					"-lz",
+					"-lstdc++",
+					"-ObjC",
+					"-all_load",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.isonapps.AssimpKit;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				USER_HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/include";
+				VALID_ARCHS = "arm64 armv7";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		77BE97DA1DDE11B30056D354 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = PRJ5CHFB5D;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = NO;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/../Code/Model/AssimpSceneKit-Prefix.pch";
+				INFOPLIST_FILE = AssimpKit/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/ios";
+				OTHER_LDFLAGS = (
+					"-lz",
+					"-lstdc++",
+					"-ObjC",
+					"-all_load",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.isonapps.AssimpKit;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				USER_HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/include";
+				VALID_ARCHS = "arm64 armv7";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		77CDAB511DD7421600B7E342 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -424,9 +623,10 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
-				ONLY_ACTIVE_ARCH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALID_ARCHS = "arm64 armv7";
 			};
 			name = Debug;
 		};
@@ -434,6 +634,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -469,6 +670,7 @@
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
+				VALID_ARCHS = "arm64 armv7";
 			};
 			name = Release;
 		};
@@ -478,19 +680,18 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = PRJ5CHFB5D;
 				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+				);
 				INFOPLIST_FILE = "iOS-Example/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/ios";
-				OTHER_LDFLAGS = (
-					"-lz",
-					"-lstdc++",
-					"-ObjC",
-					"-all_load",
-				);
+				LIBRARY_SEARCH_PATHS = "";
+				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.isonapps.iOS-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				USER_HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/include";
+				USER_HEADER_SEARCH_PATHS = "";
 			};
 			name = Debug;
 		};
@@ -500,19 +701,18 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = PRJ5CHFB5D;
 				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+				);
 				INFOPLIST_FILE = "iOS-Example/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/ios";
-				OTHER_LDFLAGS = (
-					"-lz",
-					"-lstdc++",
-					"-ObjC",
-					"-all_load",
-				);
+				LIBRARY_SEARCH_PATHS = "";
+				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.isonapps.iOS-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				USER_HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/include";
+				USER_HEADER_SEARCH_PATHS = "";
 			};
 			name = Release;
 		};
@@ -558,12 +758,9 @@
 					"TEST_ASSETS_PATH=@\\\"$(PROJECT_DIR)/../assets\\\"",
 				);
 				INFOPLIST_FILE = AssimpSceneKit_LogicTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/ios";
-				OTHER_LDFLAGS = (
-					"-lz",
-					"-lstdc++",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.isonapps.AssimpSceneKit-LogicTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				USER_HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/include";
@@ -576,12 +773,9 @@
 			buildSettings = {
 				DEVELOPMENT_TEAM = PRJ5CHFB5D;
 				INFOPLIST_FILE = AssimpSceneKit_LogicTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/ios";
-				OTHER_LDFLAGS = (
-					"-lz",
-					"-lstdc++",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.isonapps.AssimpSceneKit-LogicTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				USER_HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/include";
@@ -592,6 +786,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		77BE97DB1DDE11B30056D354 /* Build configuration list for PBXNativeTarget "AssimpKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				77BE97D91DDE11B30056D354 /* Debug */,
+				77BE97DA1DDE11B30056D354 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		77CDAB351DD7421500B7E342 /* Build configuration list for PBXProject "iOS-Example" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/AssimpKit/iOS-Example/iOS-Example.xcodeproj/project.pbxproj
+++ b/AssimpKit/iOS-Example/iOS-Example.xcodeproj/project.pbxproj
@@ -27,10 +27,6 @@
 		77CDAB4A1DD7421500B7E342 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 77CDAB481DD7421500B7E342 /* Main.storyboard */; };
 		77CDAB4C1DD7421500B7E342 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 77CDAB4B1DD7421500B7E342 /* Assets.xcassets */; };
 		77CDAB4F1DD7421600B7E342 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 77CDAB4D1DD7421600B7E342 /* LaunchScreen.storyboard */; };
-		77CDAB6B1DD7429900B7E342 /* AssimpImporter.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAB641DD7429900B7E342 /* AssimpImporter.m */; };
-		77CDAB6C1DD7429900B7E342 /* SCNAssimpAnimation.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAB661DD7429900B7E342 /* SCNAssimpAnimation.m */; };
-		77CDAB6D1DD7429900B7E342 /* SCNAssimpScene.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAB681DD7429900B7E342 /* SCNAssimpScene.m */; };
-		77CDAB6E1DD7429900B7E342 /* SCNScene+AssimpImport.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAB6A1DD7429900B7E342 /* SCNScene+AssimpImport.m */; };
 		77CDAB881DD745EA00B7E342 /* ModelLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAB861DD745EA00B7E342 /* ModelLog.m */; };
 		77CDAB8B1DD749CB00B7E342 /* AssimpImporterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 77CDAB8A1DD749CB00B7E342 /* AssimpImporterTests.m */; };
 /* End PBXBuildFile section */
@@ -42,20 +38,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 77BE97CF1DDE11B30056D354;
 			remoteInfo = AssimpKit;
-		};
-		77CDAB721DD7447600B7E342 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 77CDAB321DD7421500B7E342 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 77CDAB591DD7428900B7E342;
-			remoteInfo = AssimpSceneKit;
-		};
-		77CDAB7F1DD745D800B7E342 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 77CDAB321DD7421500B7E342 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 77CDAB591DD7428900B7E342;
-			remoteInfo = AssimpSceneKit;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -69,15 +51,6 @@
 				779DF1551DDED8D000DED366 /* AssimpKit.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		77CDAB581DD7428900B7E342 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "include/$(PRODUCT_NAME)";
-			dstSubfolderSpec = 16;
-			files = (
-			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -105,15 +78,6 @@
 		77CDAB4B1DD7421500B7E342 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		77CDAB4E1DD7421600B7E342 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		77CDAB501DD7421600B7E342 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		77CDAB5A1DD7428900B7E342 /* libAssimpSceneKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAssimpSceneKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		77CDAB631DD7429900B7E342 /* AssimpImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AssimpImporter.h; path = ../../Code/Model/AssimpImporter.h; sourceTree = "<group>"; };
-		77CDAB641DD7429900B7E342 /* AssimpImporter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AssimpImporter.m; path = ../../Code/Model/AssimpImporter.m; sourceTree = "<group>"; };
-		77CDAB651DD7429900B7E342 /* SCNAssimpAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SCNAssimpAnimation.h; path = ../../Code/Model/SCNAssimpAnimation.h; sourceTree = "<group>"; };
-		77CDAB661DD7429900B7E342 /* SCNAssimpAnimation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SCNAssimpAnimation.m; path = ../../Code/Model/SCNAssimpAnimation.m; sourceTree = "<group>"; };
-		77CDAB671DD7429900B7E342 /* SCNAssimpScene.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SCNAssimpScene.h; path = ../../Code/Model/SCNAssimpScene.h; sourceTree = "<group>"; };
-		77CDAB681DD7429900B7E342 /* SCNAssimpScene.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SCNAssimpScene.m; path = ../../Code/Model/SCNAssimpScene.m; sourceTree = "<group>"; };
-		77CDAB691DD7429900B7E342 /* SCNScene+AssimpImport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SCNScene+AssimpImport.h"; path = "../../Code/Model/SCNScene+AssimpImport.h"; sourceTree = "<group>"; };
-		77CDAB6A1DD7429900B7E342 /* SCNScene+AssimpImport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "SCNScene+AssimpImport.m"; path = "../../Code/Model/SCNScene+AssimpImport.m"; sourceTree = "<group>"; };
 		77CDAB701DD743B100B7E342 /* libassimp-fat.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libassimp-fat.a"; path = "../Assimp/lib/ios/libassimp-fat.a"; sourceTree = "<group>"; };
 		77CDAB791DD745D800B7E342 /* AssimpSceneKit_LogicTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AssimpSceneKit_LogicTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		77CDAB7D1DD745D800B7E342 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -136,13 +100,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				779DF1541DDED8D000DED366 /* AssimpKit.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		77CDAB571DD7428900B7E342 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -178,7 +135,6 @@
 			isa = PBXGroup;
 			children = (
 				77CDAB3C1DD7421500B7E342 /* iOS-Example */,
-				77CDAB5B1DD7428900B7E342 /* AssimpSceneKit */,
 				77CDAB7A1DD745D800B7E342 /* AssimpSceneKit_LogicTests */,
 				77BE97D11DDE11B30056D354 /* AssimpKit */,
 				77CDAB3B1DD7421500B7E342 /* Products */,
@@ -190,7 +146,6 @@
 			isa = PBXGroup;
 			children = (
 				77CDAB3A1DD7421500B7E342 /* iOS-Example.app */,
-				77CDAB5A1DD7428900B7E342 /* libAssimpSceneKit.a */,
 				77CDAB791DD745D800B7E342 /* AssimpSceneKit_LogicTests.xctest */,
 				77BE97D01DDE11B30056D354 /* AssimpKit.framework */,
 			);
@@ -220,21 +175,6 @@
 				77CDAB3E1DD7421500B7E342 /* main.m */,
 			);
 			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		77CDAB5B1DD7428900B7E342 /* AssimpSceneKit */ = {
-			isa = PBXGroup;
-			children = (
-				77CDAB631DD7429900B7E342 /* AssimpImporter.h */,
-				77CDAB641DD7429900B7E342 /* AssimpImporter.m */,
-				77CDAB651DD7429900B7E342 /* SCNAssimpAnimation.h */,
-				77CDAB661DD7429900B7E342 /* SCNAssimpAnimation.m */,
-				77CDAB671DD7429900B7E342 /* SCNAssimpScene.h */,
-				77CDAB681DD7429900B7E342 /* SCNAssimpScene.m */,
-				77CDAB691DD7429900B7E342 /* SCNScene+AssimpImport.h */,
-				77CDAB6A1DD7429900B7E342 /* SCNScene+AssimpImport.m */,
-			);
-			path = AssimpSceneKit;
 			sourceTree = "<group>";
 		};
 		77CDAB6F1DD743B100B7E342 /* Frameworks */ = {
@@ -304,30 +244,12 @@
 			buildRules = (
 			);
 			dependencies = (
-				77CDAB731DD7447600B7E342 /* PBXTargetDependency */,
 				779DF1571DDED8D000DED366 /* PBXTargetDependency */,
 			);
 			name = "iOS-Example";
 			productName = "iOS-Example";
 			productReference = 77CDAB3A1DD7421500B7E342 /* iOS-Example.app */;
 			productType = "com.apple.product-type.application";
-		};
-		77CDAB591DD7428900B7E342 /* AssimpSceneKit */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 77CDAB601DD7428900B7E342 /* Build configuration list for PBXNativeTarget "AssimpSceneKit" */;
-			buildPhases = (
-				77CDAB561DD7428900B7E342 /* Sources */,
-				77CDAB571DD7428900B7E342 /* Frameworks */,
-				77CDAB581DD7428900B7E342 /* CopyFiles */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = AssimpSceneKit;
-			productName = AssimpSceneKit;
-			productReference = 77CDAB5A1DD7428900B7E342 /* libAssimpSceneKit.a */;
-			productType = "com.apple.product-type.library.static";
 		};
 		77CDAB781DD745D800B7E342 /* AssimpSceneKit_LogicTests */ = {
 			isa = PBXNativeTarget;
@@ -340,7 +262,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				77CDAB801DD745D800B7E342 /* PBXTargetDependency */,
 			);
 			name = AssimpSceneKit_LogicTests;
 			productName = AssimpSceneKit_LogicTests;
@@ -366,11 +287,6 @@
 						DevelopmentTeam = PRJ5CHFB5D;
 						ProvisioningStyle = Automatic;
 					};
-					77CDAB591DD7428900B7E342 = {
-						CreatedOnToolsVersion = 8.1;
-						DevelopmentTeam = PRJ5CHFB5D;
-						ProvisioningStyle = Automatic;
-					};
 					77CDAB781DD745D800B7E342 = {
 						CreatedOnToolsVersion = 8.1;
 						DevelopmentTeam = PRJ5CHFB5D;
@@ -392,7 +308,6 @@
 			projectRoot = "";
 			targets = (
 				77CDAB391DD7421500B7E342 /* iOS-Example */,
-				77CDAB591DD7428900B7E342 /* AssimpSceneKit */,
 				77CDAB781DD745D800B7E342 /* AssimpSceneKit_LogicTests */,
 				77BE97CF1DDE11B30056D354 /* AssimpKit */,
 			);
@@ -449,17 +364,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		77CDAB561DD7428900B7E342 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				77CDAB6B1DD7429900B7E342 /* AssimpImporter.m in Sources */,
-				77CDAB6D1DD7429900B7E342 /* SCNAssimpScene.m in Sources */,
-				77CDAB6C1DD7429900B7E342 /* SCNAssimpAnimation.m in Sources */,
-				77CDAB6E1DD7429900B7E342 /* SCNScene+AssimpImport.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		77CDAB751DD745D800B7E342 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -476,16 +380,6 @@
 			isa = PBXTargetDependency;
 			target = 77BE97CF1DDE11B30056D354 /* AssimpKit */;
 			targetProxy = 779DF1561DDED8D000DED366 /* PBXContainerItemProxy */;
-		};
-		77CDAB731DD7447600B7E342 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 77CDAB591DD7428900B7E342 /* AssimpSceneKit */;
-			targetProxy = 77CDAB721DD7447600B7E342 /* PBXContainerItemProxy */;
-		};
-		77CDAB801DD745D800B7E342 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 77CDAB591DD7428900B7E342 /* AssimpSceneKit */;
-			targetProxy = 77CDAB7F1DD745D800B7E342 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -716,38 +610,6 @@
 			};
 			name = Release;
 		};
-		77CDAB611DD7428900B7E342 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				DEVELOPMENT_TEAM = PRJ5CHFB5D;
-				ENABLE_BITCODE = NO;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/../Code/Model/AssimpSceneKit-Prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/ios";
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				USER_HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/include";
-			};
-			name = Debug;
-		};
-		77CDAB621DD7428900B7E342 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				DEVELOPMENT_TEAM = PRJ5CHFB5D;
-				ENABLE_BITCODE = NO;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/../Code/Model/AssimpSceneKit-Prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/lib/ios";
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				USER_HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../Assimp/include";
-			};
-			name = Release;
-		};
 		77CDAB821DD745D800B7E342 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -809,15 +671,6 @@
 			buildConfigurations = (
 				77CDAB541DD7421600B7E342 /* Debug */,
 				77CDAB551DD7421600B7E342 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		77CDAB601DD7428900B7E342 /* Build configuration list for PBXNativeTarget "AssimpSceneKit" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				77CDAB611DD7428900B7E342 /* Debug */,
-				77CDAB621DD7428900B7E342 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/AssimpKit/iOS-Example/iOS-Example.xcodeproj/xcshareddata/xcschemes/AssimpKit.xcscheme
+++ b/AssimpKit/iOS-Example/iOS-Example.xcodeproj/xcshareddata/xcschemes/AssimpKit.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0810"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "77BE97CF1DDE11B30056D354"
+               BuildableName = "AssimpKit.framework"
+               BlueprintName = "AssimpKit"
+               ReferencedContainer = "container:iOS-Example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "77BE97CF1DDE11B30056D354"
+            BuildableName = "AssimpKit.framework"
+            BlueprintName = "AssimpKit"
+            ReferencedContainer = "container:iOS-Example.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "77BE97CF1DDE11B30056D354"
+            BuildableName = "AssimpKit.framework"
+            BlueprintName = "AssimpKit"
+            ReferencedContainer = "container:iOS-Example.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Fixes #34.

This adds a framework target which builds the AssimpKit.framework that wraps the assimp lib dependency as well. 

With this framework, one just needs to add the framework to the project without being bothered about setting up assimp and other build settings to get assimp lib working correctly.