### PR TITLE
Add anim properties

### DIFF
--- a/AssimpKit/Code/Model/SCNAssimpAnimSettings.h
+++ b/AssimpKit/Code/Model/SCNAssimpAnimSettings.h
@@ -1,0 +1,163 @@
+
+/*
+ ---------------------------------------------------------------------------
+ Assimp to Scene Kit Library (AssimpKit)
+ ---------------------------------------------------------------------------
+ Copyright (c) 2016, Deepak Surti, Ison Apps, AssimpKit team
+ All rights reserved.
+ Redistribution and use of this software in source and binary forms,
+ with or without modification, are permitted provided that the following
+ conditions are met:
+ * Redistributions of source code must retain the above
+ copyright notice, this list of conditions and the
+ following disclaimer.
+ * Redistributions in binary form must reproduce the above
+ copyright notice, this list of conditions and the
+ following disclaimer in the documentation and/or other
+ materials provided with the distribution.
+ * Neither the name of the AssimpKit team, nor the names of its
+ contributors may be used to endorse or promote products
+ derived from this software without specific prior
+ written permission of the AssimpKit team.
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ---------------------------------------------------------------------------
+ */
+
+#import <Foundation/Foundation.h>
+#import <SceneKit/SceneKit.h>
+
+/**
+ SCNAssimpAnimSettings provides support for CAMediaTiming protocol, animation
+ attributes and animating scenekit content.
+ */
+@interface SCNAssimpAnimSettings : NSObject
+
+#pragma mark - CAMediaTiming
+
+/**
+ @name CAMediaTiming
+ */
+
+/**
+ Specifies the begin time of the receiver in relation to its parent object, if
+ applicable.
+ */
+@property CFTimeInterval beginTime;
+
+/**
+  Specifies an additional time offset in active local time.
+ */
+@property CFTimeInterval timeOffset;
+
+/**
+ Determines the number of times the animation will repeat.
+ */
+@property float repeatCount;
+
+/**
+ Determines how many seconds the animation will repeat for.
+ */
+@property CFTimeInterval repeatDuration;
+
+/**
+ Specifies the basic duration of the animation, in seconds.
+ */
+@property CFTimeInterval duration;
+
+/**
+ Specifies how time is mapped to receiver’s time space from the parent time
+ space.
+ */
+@property float speed;
+
+/**
+ Determines if the receiver plays in the reverse upon completion.
+ */
+@property BOOL autoreverses;
+
+/**
+ Determines if the receiver’s presentation is frozen or removed once its active
+ duration has completed.
+ */
+@property (copy) NSString *fillMode;
+
+#pragma mark - Animation attributes
+
+/**
+ @name Animation attributes
+ */
+/**
+ Determines if the animation is removed from the target layer’s animations upon
+ completion.
+ */
+@property (getter=isRemovedOnCompletion) BOOL removedOnCompletion;
+
+/**
+ An optional timing function defining the pacing of the animation.
+ */
+@property (strong) CAMediaTimingFunction *timingFunction;
+
+#pragma mark - Getting and setting the delegate
+
+/**
+ @name Getting and setting the delegate
+*/
+
+/**
+ Specifies the receiver’s delegate object.
+ */
+@property (strong) id<CAAnimationDelegate> delegate;
+
+#pragma mark - Controlling SceneKit Animation Timing
+
+/**
+ Controlling SceneKit Animation Timing
+ */
+
+/**
+ For animations attached to SceneKit objects, a Boolean value that determines
+ whether the animation is evaluated using the scene time or the system time.
+ */
+@property BOOL usesSceneTimeBase;
+
+#pragma mark - Fading Between SceneKit Animations
+
+/**
+ Fading Between SceneKit Animations
+ */
+
+/**
+ For animations attached to SceneKit objects, the duration for transitioning
+ into the animation’s effect as it begins.
+ */
+@property CGFloat fadeInDuration;
+
+/**
+ For animations attached to SceneKit objects, the duration for transitioning out
+ of the animation’s effect as it ends.
+ */
+@property CGFloat fadeOutDuration;
+
+#pragma mark - Attaching SceneKit Animation Events
+
+/**
+ Attaching SceneKit Animation Events
+ */
+
+/**
+ For animations attached to SceneKit objects, a list of events attached to an
+ animation.
+ */
+@property (nonatomic, copy) NSArray<SCNAnimationEvent *> *animationEvents;
+
+@end

--- a/AssimpKit/Code/Model/SCNAssimpAnimSettings.m
+++ b/AssimpKit/Code/Model/SCNAssimpAnimSettings.m
@@ -1,0 +1,74 @@
+
+/*
+ ---------------------------------------------------------------------------
+ Assimp to Scene Kit Library (AssimpKit)
+ ---------------------------------------------------------------------------
+ Copyright (c) 2016, Deepak Surti, Ison Apps, AssimpKit team
+ All rights reserved.
+ Redistribution and use of this software in source and binary forms,
+ with or without modification, are permitted provided that the following
+ conditions are met:
+ * Redistributions of source code must retain the above
+ copyright notice, this list of conditions and the
+ following disclaimer.
+ * Redistributions in binary form must reproduce the above
+ copyright notice, this list of conditions and the
+ following disclaimer in the documentation and/or other
+ materials provided with the distribution.
+ * Neither the name of the AssimpKit team, nor the names of its
+ contributors may be used to endorse or promote products
+ derived from this software without specific prior
+ written permission of the AssimpKit team.
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ---------------------------------------------------------------------------
+ */
+
+#import "SCNAssimpAnimSettings.h"
+
+/**
+ SCNAssimpAnimSettings provides support for CAMediaTiming protocol, animation
+ attributes and animating scenekit content.
+ */
+@implementation SCNAssimpAnimSettings
+
+
+/**
+ Makes an animation settings object with the default values.
+
+ @return A settings object with the default values.
+ */
+-(id)init
+{
+    self = [super init];
+    if (self) {
+        self.beginTime = 0;
+        self.timeOffset = 0;
+        self.repeatCount = 0;
+        self.repeatDuration = 0;
+        self.duration = 0;
+        self.speed = 1.0;
+        self.autoreverses = NO;
+        self.fillMode = kCAFillModeRemoved;
+        
+        self.removedOnCompletion = YES;
+        self.timingFunction = nil;
+        
+        self.usesSceneTimeBase = NO;
+        
+        self.fadeInDuration = 0;
+        self.fadeOutDuration = 0;
+    }
+    return self;
+}
+
+@end

--- a/AssimpKit/Code/Model/SCNNode+AssimpImport.h
+++ b/AssimpKit/Code/Model/SCNNode+AssimpImport.h
@@ -51,4 +51,19 @@
  */
 - (void)addAnimationScene:(SCNScene *)animScene;
 
+/**
+ Adds the animation at the given node subtree to the corresponding node subtree
+ in the scene.
+ 
+ @param animNode The node and it's subtree which has a CAAnimation.
+ */
+- (void)addAnimationFromNode:(SCNNode *)animNode;
+
+/**
+ Finds the root node of the skeleton in the scene.
+
+ @return Retuns the root node of the skeleton in the scene.
+ */
+-(SCNNode*)findSkeletonRootNode;
+
 @end

--- a/AssimpKit/Code/Model/SCNNode+AssimpImport.h
+++ b/AssimpKit/Code/Model/SCNNode+AssimpImport.h
@@ -35,35 +35,82 @@
 
 #import <Foundation/Foundation.h>
 #import <SceneKit/SceneKit.h>
+#import "SCNAssimpAnimSettings.h"
 
 @interface SCNNode (AssimpImport)
 
-#pragma mark - Adding animation
+#pragma mark - SCNAnimatable Clone
 
 /**
- @name Adding animation
+ @name SCNAnimatable Clone
  */
 
 /**
- Adds a skeletal animation scene to the scene.
- 
+ Adds an animation object for the specified key..
+
  @param animScene The scene object representing the animation.
+ @param animKey An string identifying the animation for later retrieval. You may
+ pass nil if you don’t need to reference the animation later.
+ @param settings The animation settings object.
  */
-- (void)addAnimationScene:(SCNScene *)animScene;
+- (void)addAnimationScene:(SCNScene *)animScene
+                   forKey:(NSString *)animKey
+             withSettings:(SCNAssimpAnimSettings *)settings;
 
 /**
- Adds the animation at the given node subtree to the corresponding node subtree
- in the scene.
- 
- @param animNode The node and it's subtree which has a CAAnimation.
+ Removes the animation attached to the object with the specified key.
+
+ @param animKey A string identifying an attached animation to remove.
  */
-- (void)addAnimationFromNode:(SCNNode *)animNode;
+- (void)removeAnimationSceneForKey:(NSString *)animKey;
+
+/**
+ Removes the animation attached to the object with the specified key, smoothly
+ transitioning out of the animation’s effect.
+
+ @param animKey A string identifying an attached animation to remove.
+ @param fadeOutDuration The duration for transitioning out of the animation’s
+ effect before it is removed
+ */
+- (void)removeAnimationSceneForKey:(NSString *)animKey
+                   fadeOutDuration:(CGFloat)fadeOutDuration;
+
+/**
+ Pauses the animation attached to the object with the specified key.
+
+ @param animKey A string identifying an attached animation.
+ */
+- (void)pauseAnimationSceneForKey:(NSString *)animKey;
+
+/**
+ Resumes a previously paused animation attached to the object with the specified
+ key.
+
+ @param animKey A string identifying an attached animation.
+ */
+- (void)resumeAnimationSceneForKey:(NSString *)animKey;
+
+/**
+ Returns a Boolean value indicating whether the animation attached to the object
+ with the specified key is paused.
+
+ @param animKey A string identifying an attached animation.
+ @return YES if the specified animation is paused. NO if the animation is
+ running or no animation is attached to the object with that key.
+ */
+- (BOOL)isAnimationSceneForKeyPaused:(NSString *)animKey;
+
+#pragma mark - Skeleton
+
+/**
+ @name Skeleton
+ */
 
 /**
  Finds the root node of the skeleton in the scene.
 
  @return Retuns the root node of the skeleton in the scene.
  */
--(SCNNode*)findSkeletonRootNode;
+- (SCNNode *)findSkeletonRootNode;
 
 @end

--- a/AssimpKit/Code/Model/SCNNode+AssimpImport.h
+++ b/AssimpKit/Code/Model/SCNNode+AssimpImport.h
@@ -37,6 +37,9 @@
 #import <SceneKit/SceneKit.h>
 #import "SCNAssimpAnimSettings.h"
 
+/**
+ A scenekit SCNNode category which imitates the SCNAnimatable protocol.
+ */
 @interface SCNNode (AssimpImport)
 
 #pragma mark - SCNAnimatable Clone

--- a/AssimpKit/Code/Model/SCNNode+AssimpImport.m
+++ b/AssimpKit/Code/Model/SCNNode+AssimpImport.m
@@ -72,19 +72,8 @@
  */
 - (void)addAnimationScene:(SCNScene *)animScene
 {
-    __block SCNNode *rootAnimNode = nil;
-        // find root of skeleton
-    [animScene.rootNode
-     enumerateChildNodesUsingBlock:^(SCNNode *child, BOOL *stop) {
-         if (child.animationKeys.count > 0)
-         {
-             DLog(@" found anim: %@ at node %@", child.animationKeys, child);
-             rootAnimNode = child;
-             *stop = YES;
-         }
-         
-     }];
-    
+    SCNNode* rootAnimNode = [animScene.rootNode findSkeletonRootNode];
+
     if (rootAnimNode.childNodes.count > 0)
     {
         [self addAnimationFromNode:rootAnimNode];
@@ -96,6 +85,27 @@
              rootAnimNode.parentNode.childNodes.count);
         [self addAnimationFromNode:rootAnimNode.parentNode];
     }
+}
+
+/**
+ Finds the root node of the skeleton in the scene.
+ 
+ @return Retuns the root node of the skeleton in the scene.
+ */
+-(SCNNode*)findSkeletonRootNode
+{
+    __block SCNNode *rootAnimNode = nil;
+        // find root of skeleton
+    [self
+     enumerateChildNodesUsingBlock:^(SCNNode *child, BOOL *stop) {
+         if (child.animationKeys.count > 0)
+         {
+             DLog(@" found anim: %@ at node %@", child.animationKeys, child);
+             rootAnimNode = child;
+             *stop = YES;
+         }
+     }];
+    return rootAnimNode;
 }
 
 @end

--- a/AssimpKit/Code/Model/SCNNode+AssimpImport.m
+++ b/AssimpKit/Code/Model/SCNNode+AssimpImport.m
@@ -33,78 +33,297 @@
  ---------------------------------------------------------------------------
  */
 
-#import "SCNNode+AssimpImport.h"
 #import <SceneKit/SceneKit.h>
+#import "SCNNode+AssimpImport.h"
 
 @implementation SCNNode (AssimpImport)
-#pragma mark - Adding animation
+
+#pragma mark - SCNAnimatable Clone
 
 /**
- @name Adding animation
+ @name SCNAnimatable Clone
  */
 
 /**
  Adds the animation at the given node subtree to the corresponding node subtree
  in the scene.
- 
+
  @param animNode The node and it's subtree which has a CAAnimation.
  */
 - (void)addAnimationFromNode:(SCNNode *)animNode
+                      forKey:(NSString *)animKey
+                withSettings:(SCNAssimpAnimSettings *)settings
+                   hasEvents:(BOOL)hasEvents
+                 hasDelegate:(BOOL)hasDelegate
 {
-    for (NSString *animKey in animNode.animationKeys)
+    for (NSString *nodeAnimKey in animNode.animationKeys)
     {
-        CAAnimation *animation = [animNode animationForKey:animKey];
+        CAAnimation *animation = [animNode animationForKey:nodeAnimKey];
+
+        // CAMediaTiming
+        animation.beginTime = settings.beginTime;
+        animation.timeOffset = settings.timeOffset;
+        animation.repeatCount = settings.repeatCount;
+        animation.repeatDuration = settings.repeatDuration;
+        if (animation.duration == 0)
+        {
+            animation.duration = settings.duration;
+        }
+        animation.speed = settings.speed;
+        animation.autoreverses = settings.autoreverses;
+        animation.fillMode = settings.fillMode;
+
+        // Animation attributes
+        animation.removedOnCompletion = settings.removedOnCompletion;
+        animation.timingFunction = settings.timingFunction;
+
+        // Controlling SceneKit Animation Timing
+        animation.usesSceneTimeBase = settings.usesSceneTimeBase;
+
+        // Fading Between SceneKit Animations
+        animation.fadeInDuration = settings.fadeInDuration;
+        animation.fadeOutDuration = settings.fadeOutDuration;
+
+        if (hasEvents)
+        {
+            animation.animationEvents = settings.animationEvents;
+            hasEvents = NO;
+        }
+        if (hasDelegate)
+        {
+            animation.delegate = settings.delegate;
+            hasDelegate = NO;
+        }
+
         NSString *boneName = animNode.name;
         SCNNode *sceneBoneNode =
-        [self childNodeWithName:boneName recursively:YES];
-        [sceneBoneNode addAnimation:animation forKey:animKey];
+            [self childNodeWithName:boneName recursively:YES];
+        NSString *key = [[nodeAnimKey stringByAppendingString:@"-"]
+            stringByAppendingString:animKey];
+        [sceneBoneNode addAnimation:animation forKey:key];
     }
     for (SCNNode *childNode in animNode.childNodes)
     {
-        [self addAnimationFromNode:childNode];
+        [self addAnimationFromNode:childNode
+                            forKey:animKey
+                      withSettings:settings
+                         hasEvents:hasEvents
+                       hasDelegate:hasDelegate];
     }
 }
 
 /**
  Adds a skeletal animation scene to the scene.
- 
+
  @param animScene The scene object representing the animation.
  */
 - (void)addAnimationScene:(SCNScene *)animScene
+                   forKey:(NSString *)animKey
+             withSettings:(SCNAssimpAnimSettings *)settings
 {
-    SCNNode* rootAnimNode = [animScene.rootNode findSkeletonRootNode];
+    SCNNode *rootAnimNode = [animScene.rootNode findSkeletonRootNode];
+
+    SCNAssimpAnimSettings *defaultSettings =
+        [[SCNAssimpAnimSettings alloc] init];
+
+    if (settings == nil)
+    {
+        settings = defaultSettings;
+    }
+
+    BOOL hasEvents = settings.animationEvents.count > 0;
+    BOOL hasDelegate = (settings.delegate != nil);
 
     if (rootAnimNode.childNodes.count > 0)
     {
-        [self addAnimationFromNode:rootAnimNode];
+        [self addAnimationFromNode:rootAnimNode
+                            forKey:animKey
+                      withSettings:settings
+                         hasEvents:hasEvents
+                       hasDelegate:hasDelegate];
     }
     else
     {
-            // no root exists, so add animation data to all bones
+        // no root exists, so add animation data to all bones
         DLog(@" no root: %@ %d", rootAnimNode.parentNode,
              rootAnimNode.parentNode.childNodes.count);
-        [self addAnimationFromNode:rootAnimNode.parentNode];
+        [self addAnimationFromNode:rootAnimNode.parentNode
+                            forKey:animKey
+                      withSettings:settings
+                         hasEvents:hasEvents
+                       hasDelegate:hasDelegate];
     }
 }
 
+- (void)removeAnimationAtNode:(SCNNode *)animNode
+                       forKey:(NSString *)animKey
+              fadeOutDuration:(CGFloat)fadeOutDuration
+                 withSuffixes:(NSArray *)suffixes
+{
+    if (animNode.name != nil)
+    {
+        NSString *keyPrefix = [@"/node-" stringByAppendingString:animNode.name];
+        for (NSString *suffix in suffixes)
+        {
+            NSString *key = [[keyPrefix stringByAppendingString:suffix]
+                stringByAppendingString:animKey];
+            [animNode removeAnimationForKey:key];
+        }
+    }
+    for (SCNNode *child in animNode.childNodes)
+    {
+        [self removeAnimationAtNode:child
+                             forKey:animKey
+                    fadeOutDuration:0.0
+                       withSuffixes:suffixes];
+    }
+}
+
+- (void)removeAnimationSceneForKey:(NSString *)animKey
+{
+    NSArray *suffixes = [[NSArray alloc]
+        initWithObjects:@".transform.translation-", @".transform.quaternion-",
+                        @".transform.scale-", nil];
+    [self removeAnimationAtNode:self
+                         forKey:animKey
+                fadeOutDuration:0.0
+                   withSuffixes:suffixes];
+}
+
+- (void)removeAnimationSceneForKey:(NSString *)animKey
+                   fadeOutDuration:(CGFloat)fadeOutDuration
+{
+    NSArray *suffixes = [[NSArray alloc]
+        initWithObjects:@".transform.translation-", @".transform.quaternion-",
+                        @".transform.scale-", nil];
+    [self removeAnimationAtNode:self
+                         forKey:animKey
+                fadeOutDuration:fadeOutDuration
+                   withSuffixes:suffixes];
+}
+
+- (void)pauseAnimationAtNode:(SCNNode *)animNode
+                      forKey:(NSString *)animKey
+                withSuffixes:(NSArray *)suffixes
+{
+    if (animNode.name != nil)
+    {
+        NSString *keyPrefix = [@"/node-" stringByAppendingString:animNode.name];
+        for (NSString *suffix in suffixes)
+        {
+            NSString *key = [[keyPrefix stringByAppendingString:suffix]
+                stringByAppendingString:animKey];
+            NSLog(@" pausing animation with key: %@", key);
+            [animNode pauseAnimationForKey:key];
+        }
+    }
+    for (SCNNode *child in animNode.childNodes)
+    {
+        [self pauseAnimationAtNode:child forKey:animKey withSuffixes:suffixes];
+    }
+}
+
+- (void)pauseAnimationSceneForKey:(NSString *)animKey
+{
+    NSArray *suffixes = [[NSArray alloc]
+        initWithObjects:@".transform.translation-", @".transform.quaternion-",
+                        @".transform.scale-", nil];
+    [self pauseAnimationAtNode:self forKey:animKey withSuffixes:suffixes];
+}
+
+- (void)resumeAnimationAtNode:(SCNNode *)animNode
+                       forKey:(NSString *)animKey
+                 withSuffixes:(NSArray *)suffixes
+{
+    if (animNode.name != nil)
+    {
+        NSString *keyPrefix = [@"/node-" stringByAppendingString:animNode.name];
+        for (NSString *suffix in suffixes)
+        {
+            NSString *key = [[keyPrefix stringByAppendingString:suffix]
+                stringByAppendingString:animKey];
+            NSLog(@" resuming animation with key: %@", key);
+            [animNode resumeAnimationForKey:key];
+        }
+    }
+    for (SCNNode *child in animNode.childNodes)
+    {
+        [self resumeAnimationAtNode:child forKey:animKey withSuffixes:suffixes];
+    }
+}
+
+- (void)resumeAnimationSceneForKey:(NSString *)animKey
+{
+    NSArray *suffixes = [[NSArray alloc]
+        initWithObjects:@".transform.translation-", @".transform.quaternion-",
+                        @".transform.scale-", nil];
+    [self resumeAnimationAtNode:self forKey:animKey withSuffixes:suffixes];
+}
+
+- (BOOL)isAnimationForScenePausedAtNode:(SCNNode *)animNode
+                                 forKey:(NSString *)animKey
+                           withSuffixes:(NSArray *)suffixes
+{
+    BOOL paused = NO;
+    if (animNode.name != nil)
+    {
+        NSString *keyPrefix = [@"/node-" stringByAppendingString:animNode.name];
+        for (NSString *suffix in suffixes)
+        {
+            NSString *key = [[keyPrefix stringByAppendingString:suffix]
+                stringByAppendingString:animKey];
+            NSLog(@" resuming animation with key: %@", key);
+            paused = [animNode isAnimationForKeyPaused:key];
+        }
+    }
+    if(paused)
+    {
+        return paused;
+    } else
+    {
+        for (SCNNode *child in animNode.childNodes)
+        {
+            paused = [self isAnimationForScenePausedAtNode:child
+                                                    forKey:animKey
+                                              withSuffixes:suffixes];
+        }
+    }
+    return paused;
+}
+
+- (BOOL)isAnimationSceneForKeyPaused:(NSString *)animKey
+{
+    NSArray *suffixes = [[NSArray alloc]
+                         initWithObjects:@".transform.translation-", @".transform.quaternion-",
+                         @".transform.scale-", nil];
+    return [self isAnimationForScenePausedAtNode:self
+                                          forKey:animKey
+                                    withSuffixes:suffixes];
+}
+
+#pragma mark - Skeleton
+
+/**
+ @name Skeleton
+ */
+
 /**
  Finds the root node of the skeleton in the scene.
- 
+
  @return Retuns the root node of the skeleton in the scene.
  */
--(SCNNode*)findSkeletonRootNode
+- (SCNNode *)findSkeletonRootNode
 {
     __block SCNNode *rootAnimNode = nil;
-        // find root of skeleton
-    [self
-     enumerateChildNodesUsingBlock:^(SCNNode *child, BOOL *stop) {
-         if (child.animationKeys.count > 0)
-         {
-             DLog(@" found anim: %@ at node %@", child.animationKeys, child);
-             rootAnimNode = child;
-             *stop = YES;
-         }
-     }];
+    // find root of skeleton
+    [self enumerateChildNodesUsingBlock:^(SCNNode *child, BOOL *stop) {
+      if (child.animationKeys.count > 0)
+      {
+          DLog(@" found anim: %@ at node %@", child.animationKeys, child);
+          rootAnimNode = child;
+          *stop = YES;
+      }
+    }];
     return rootAnimNode;
 }
 

--- a/AssimpKit/Code/Model/SCNScene+AssimpImport.h
+++ b/AssimpKit/Code/Model/SCNScene+AssimpImport.h
@@ -84,16 +84,4 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 + (SCNAssimpScene *)assimpSceneWithURL:(NSURL *)url
                       postProcessFlags:(unsigned int)postProcessFlags;
 
-#pragma mark - Adding animation
-
-/**
- @name Adding animation
- */
-
-/**
- Adds a skeletal animation scene to the scene.
-
- @param animScene The scene object representing the animation.
- */
-- (void)addAnimationScene:(SCNScene *)animScene;
 @end

--- a/AssimpKit/Code/Model/SCNScene+AssimpImport.m
+++ b/AssimpKit/Code/Model/SCNScene+AssimpImport.m
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #import "AssimpImporter.h"
 #import "SCNScene+AssimpImport.h"
+#import "SCNNode+AssimpImport.h"
 
 @implementation SCNScene (AssimpImport)
 
@@ -116,67 +117,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     AssimpImporter *assimpImporter = [[AssimpImporter alloc] init];
     return
         [assimpImporter importScene:url.path postProcessFlags:postProcessFlags];
-}
-
-#pragma mark - Adding animation
-
-/**
- @name Adding animation
- */
-
-/**
- Adds the animation at the given node subtree to the corresponding node subtree
- in the scene.
-
- @param animNode The node and it's subtree which has a CAAnimation.
- */
-- (void)addAnimationFromNode:(SCNNode *)animNode
-{
-    for (NSString *animKey in animNode.animationKeys)
-    {
-        CAAnimation *animation = [animNode animationForKey:animKey];
-        NSString *boneName = animNode.name;
-        SCNNode *sceneBoneNode =
-            [self.rootNode childNodeWithName:boneName recursively:YES];
-        [sceneBoneNode addAnimation:animation forKey:animKey];
-    }
-    for (SCNNode *childNode in animNode.childNodes)
-    {
-        [self addAnimationFromNode:childNode];
-    }
-}
-
-/**
- Adds a skeletal animation scene to the scene.
-
- @param animScene The scene object representing the animation.
- */
-- (void)addAnimationScene:(SCNScene *)animScene
-{
-    __block SCNNode *rootAnimNode = nil;
-    // find root of skeleton
-    [animScene.rootNode
-        enumerateChildNodesUsingBlock:^(SCNNode *child, BOOL *stop) {
-          if (child.animationKeys.count > 0)
-          {
-              DLog(@" found anim: %@ at node %@", child.animationKeys, child);
-              rootAnimNode = child;
-              *stop = YES;
-          }
-
-        }];
-
-    if (rootAnimNode.childNodes.count > 0)
-    {
-        [self addAnimationFromNode:rootAnimNode];
-    }
-    else
-    {
-        // no root exists, so add animation data to all bones
-        DLog(@" no root: %@ %d", rootAnimNode.parentNode,
-              rootAnimNode.parentNode.childNodes.count);
-        [self addAnimationFromNode:rootAnimNode.parentNode];
-    }
 }
 
 @end

--- a/AssimpKit/Code/Model/SCNScene+AssimpImport.m
+++ b/AssimpKit/Code/Model/SCNScene+AssimpImport.m
@@ -34,8 +34,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #import "AssimpImporter.h"
-#import "SCNScene+AssimpImport.h"
 #import "SCNNode+AssimpImport.h"
+#import "SCNScene+AssimpImport.h"
 
 @implementation SCNScene (AssimpImport)
 

--- a/AssimpKit/Library/Library.xcodeproj/project.pbxproj
+++ b/AssimpKit/Library/Library.xcodeproj/project.pbxproj
@@ -18,6 +18,10 @@
 		7746DB741DEF08FE00C651DC /* not-supported-formats.txt in Resources */ = {isa = PBXBuildFile; fileRef = 7746DB731DEF08FE00C651DC /* not-supported-formats.txt */; };
 		7746DB751DEF090500C651DC /* not-supported-formats.txt in Resources */ = {isa = PBXBuildFile; fileRef = 7746DB731DEF08FE00C651DC /* not-supported-formats.txt */; };
 		7746DB771DEF0DFA00C651DC /* SCNSceneTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7746DB761DEF0DFA00C651DC /* SCNSceneTests.m */; };
+		77824E3C1E1A5B21000B24A3 /* SCNAssimpAnimSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 77824E3A1E1A5B21000B24A3 /* SCNAssimpAnimSettings.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		77824E3D1E1A5B21000B24A3 /* SCNAssimpAnimSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 77824E3B1E1A5B21000B24A3 /* SCNAssimpAnimSettings.m */; };
+		77824E421E1A5B45000B24A3 /* SCNAssimpAnimSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 77824E401E1A5B45000B24A3 /* SCNAssimpAnimSettings.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		77824E431E1A5B45000B24A3 /* SCNAssimpAnimSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 77824E411E1A5B45000B24A3 /* SCNAssimpAnimSettings.m */; };
 		779DF1DC1DDF29FF00DED366 /* libassimp-fat.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 779DF1DB1DDF29FF00DED366 /* libassimp-fat.a */; };
 		779DF1E61DDF2A5700DED366 /* AssimpImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 779DF1DD1DDF2A5700DED366 /* AssimpImporter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		779DF1E71DDF2A5700DED366 /* AssimpImporter.m in Sources */ = {isa = PBXBuildFile; fileRef = 779DF1DE1DDF2A5700DED366 /* AssimpImporter.m */; };
@@ -91,6 +95,10 @@
 		7746DB701DEEFE4000C651DC /* SCNSceneTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SCNSceneTests.m; path = ../../Code/Model/Tests/SCNSceneTests.m; sourceTree = "<group>"; };
 		7746DB731DEF08FE00C651DC /* not-supported-formats.txt */ = {isa = PBXFileReference; lastKnownFileType = text; name = "not-supported-formats.txt"; path = "../assets/not-supported-formats.txt"; sourceTree = "<group>"; };
 		7746DB761DEF0DFA00C651DC /* SCNSceneTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SCNSceneTests.m; path = ../../Code/Model/Tests/SCNSceneTests.m; sourceTree = "<group>"; };
+		77824E3A1E1A5B21000B24A3 /* SCNAssimpAnimSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SCNAssimpAnimSettings.h; path = ../../Code/Model/SCNAssimpAnimSettings.h; sourceTree = "<group>"; };
+		77824E3B1E1A5B21000B24A3 /* SCNAssimpAnimSettings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SCNAssimpAnimSettings.m; path = ../../Code/Model/SCNAssimpAnimSettings.m; sourceTree = "<group>"; };
+		77824E401E1A5B45000B24A3 /* SCNAssimpAnimSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SCNAssimpAnimSettings.h; path = ../../Code/Model/SCNAssimpAnimSettings.h; sourceTree = "<group>"; };
+		77824E411E1A5B45000B24A3 /* SCNAssimpAnimSettings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SCNAssimpAnimSettings.m; path = ../../Code/Model/SCNAssimpAnimSettings.m; sourceTree = "<group>"; };
 		779DF1A71DDF262500DED366 /* libassimp.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libassimp.a; path = ../Assimp/lib/osx/libassimp.a; sourceTree = "<group>"; };
 		779DF1D31DDF29F200DED366 /* AssimpKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AssimpKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		779DF1D61DDF29F200DED366 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -208,6 +216,8 @@
 		779DF1D41DDF29F200DED366 /* AssimpKit-iOS */ = {
 			isa = PBXGroup;
 			children = (
+				77824E401E1A5B45000B24A3 /* SCNAssimpAnimSettings.h */,
+				77824E411E1A5B45000B24A3 /* SCNAssimpAnimSettings.m */,
 				7746DB5C1DEEBFE600C651DC /* PostProcessingFlags.h */,
 				779DF1DD1DDF2A5700DED366 /* AssimpImporter.h */,
 				779DF1DE1DDF2A5700DED366 /* AssimpImporter.m */,
@@ -241,6 +251,8 @@
 				779DF1FE1DDF2B8700DED366 /* Info.plist */,
 				77EB2B881E1776EB004FA171 /* SCNNode+AssimpImport.h */,
 				77EB2B891E1776EB004FA171 /* SCNNode+AssimpImport.m */,
+				77824E3A1E1A5B21000B24A3 /* SCNAssimpAnimSettings.h */,
+				77824E3B1E1A5B21000B24A3 /* SCNAssimpAnimSettings.m */,
 			);
 			path = "AssimpKit-macOS";
 			sourceTree = "<group>";
@@ -302,6 +314,7 @@
 				779DF1E61DDF2A5700DED366 /* AssimpImporter.h in Headers */,
 				7746DB5D1DEEBFE600C651DC /* PostProcessingFlags.h in Headers */,
 				77EB2B901E17773B004FA171 /* SCNNode+AssimpImport.h in Headers */,
+				77824E421E1A5B45000B24A3 /* SCNAssimpAnimSettings.h in Headers */,
 				779DF1ED1DDF2A5700DED366 /* SCNScene+AssimpImport.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -316,6 +329,7 @@
 				779DF20C1DDF2BB000DED366 /* AssimpImporter.h in Headers */,
 				7746DB5F1DEED16E00C651DC /* PostProcessingFlags.h in Headers */,
 				77EB2B8A1E1776EB004FA171 /* SCNNode+AssimpImport.h in Headers */,
+				77824E3C1E1A5B21000B24A3 /* SCNAssimpAnimSettings.h in Headers */,
 				779DF2131DDF2BB000DED366 /* SCNScene+AssimpImport.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -515,6 +529,7 @@
 				77EB2B911E17773B004FA171 /* SCNNode+AssimpImport.m in Sources */,
 				779DF1EC1DDF2A5700DED366 /* SCNAssimpScene.m in Sources */,
 				779DF1EA1DDF2A5700DED366 /* SCNAssimpAnimation.m in Sources */,
+				77824E431E1A5B45000B24A3 /* SCNAssimpAnimSettings.m in Sources */,
 				779DF1E71DDF2A5700DED366 /* AssimpImporter.m in Sources */,
 				779DF1EE1DDF2A5700DED366 /* SCNScene+AssimpImport.m in Sources */,
 			);
@@ -527,6 +542,7 @@
 				77EB2B8B1E1776EB004FA171 /* SCNNode+AssimpImport.m in Sources */,
 				779DF2121DDF2BB000DED366 /* SCNAssimpScene.m in Sources */,
 				779DF2101DDF2BB000DED366 /* SCNAssimpAnimation.m in Sources */,
+				77824E3D1E1A5B21000B24A3 /* SCNAssimpAnimSettings.m in Sources */,
 				779DF20D1DDF2BB000DED366 /* AssimpImporter.m in Sources */,
 				779DF2141DDF2BB000DED366 /* SCNScene+AssimpImport.m in Sources */,
 			);

--- a/AssimpKit/Library/OSX-Example/OSX-Example/GameViewController.h
+++ b/AssimpKit/Library/OSX-Example/OSX-Example/GameViewController.h
@@ -34,10 +34,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #import <SceneKit/SceneKit.h>
+#import <Quartz/Quartz.h>
 
 #import "GameView.h"
 
-@interface GameViewController : NSViewController
+@interface GameViewController : NSViewController <CAAnimationDelegate>
 
 @property (assign) IBOutlet GameView *gameView;
 

--- a/AssimpKit/Library/OSX-Example/OSX-Example/GameViewController.m
+++ b/AssimpKit/Library/OSX-Example/OSX-Example/GameViewController.m
@@ -35,8 +35,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #import "GameViewController.h"
 #import <AssimpKit/PostProcessingFlags.h>
-#import <AssimpKit/SCNScene+AssimpImport.h>
 #import <AssimpKit/SCNNode+AssimpImport.h>
+#import <AssimpKit/SCNScene+AssimpImport.h>
 
 @implementation GameViewController
 
@@ -87,7 +87,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
               postProcessFlags:AssimpKit_Process_FlipUVs |
                                AssimpKit_Process_Triangulate];
         SCNScene *scene = self.gameView.scene;
-        if (scene == nil) {
+        if (scene == nil)
+        {
             scene = animScene.modelScene;
             self.gameView.scene = scene;
         }
@@ -95,14 +96,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         // If multiple animations exist, load the first animation
         if (animationKeys.count > 0)
         {
-            SCNScene* animation = [animScene animationSceneForKey:[animationKeys objectAtIndex:0]];
-            [scene addAnimationScene:animation];
-            
-            /** You can also use the SCNNode category to add animation
-            
-             [scene.rootNode addAnimationScene:animation];
-             
-            */
+            SCNScene *animation = [animScene
+                animationSceneForKey:[animationKeys objectAtIndex:0]];
+            [scene.rootNode addAnimationScene:animation];
         }
     }
 }

--- a/AssimpKit/Library/iOS-Example/iOS-Example/GameViewController.h
+++ b/AssimpKit/Library/iOS-Example/iOS-Example/GameViewController.h
@@ -36,7 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #import <SceneKit/SceneKit.h>
 #import <UIKit/UIKit.h>
 
-@interface GameViewController : UIViewController
+@interface GameViewController : UIViewController <CAAnimationDelegate>
 
 @property(readwrite, nonatomic) NSString* modelFilePath;
 @property(readwrite, nonatomic) NSString* animFilePath;

--- a/AssimpKit/Library/iOS-Example/iOS-Example/GameViewController.m
+++ b/AssimpKit/Library/iOS-Example/iOS-Example/GameViewController.m
@@ -35,8 +35,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #import "GameViewController.h"
 #import <AssimpKit/PostProcessingFlags.h>
-#import <AssimpKit/SCNScene+AssimpImport.h>
 #import <AssimpKit/SCNNode+AssimpImport.h>
+#import <AssimpKit/SCNScene+AssimpImport.h>
 
 @implementation GameViewController
 
@@ -61,8 +61,37 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         // If multiple animations exist, load the first animation
         if (animationKeys.count > 0)
         {
-            SCNScene* animation = [animScene animationSceneForKey:[animationKeys objectAtIndex:0]];            
-            [scene.modelScene.rootNode addAnimationScene:animation];
+            SCNAssimpAnimSettings *settings =
+                [[SCNAssimpAnimSettings alloc] init];
+            settings.repeatCount = 3;
+
+            NSString *key = [animationKeys objectAtIndex:0];
+            SCNAnimationEventBlock eventBlock =
+                ^(CAAnimation *animation, id animatedObject,
+                  BOOL playingBackward) {
+                  NSLog(@" Animation Event triggered ");
+
+                  // To test removing animation uncomment
+                  // Then the animation wont repeat 3 times
+                  // as it will be removed after 90% of the first loop
+                  // is completed, as event key time is 0.9
+                  // [scene.rootNode removeAnimationSceneForKey:key
+                  //                            fadeOutDuration:0.3];
+                  // [scene.rootNode pauseAnimationSceneForKey:key];
+                  // [scene.rootNode resumeAnimationSceneForKey:key];
+                };
+            SCNAnimationEvent *animEvent =
+                [SCNAnimationEvent animationEventWithKeyTime:0.1f
+                                                       block:eventBlock];
+            NSArray *animEvents =
+                [[NSArray alloc] initWithObjects:animEvent, nil];
+            settings.animationEvents = animEvents;
+            settings.delegate = self;
+
+            SCNScene *animation = [animScene animationSceneForKey:key];
+            [scene.modelScene.rootNode addAnimationScene:animation
+                                                  forKey:key
+                                            withSettings:settings];
         }
     }
 
@@ -82,6 +111,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     scnView.backgroundColor = [UIColor blackColor];
 
     scnView.playing = YES;
+}
+
+- (void)animationDidStart:(CAAnimation *)anim
+{
+    NSLog(@" animation did start...");
+}
+
+- (void)animationDidStop:(CAAnimation *)anim finished:(BOOL)flag
+{
+    NSLog(@" animation did stop...");
 }
 
 - (BOOL)shouldAutorotate

--- a/AssimpKit/Library/iOS-Example/iOS-Example/GameViewController.m
+++ b/AssimpKit/Library/iOS-Example/iOS-Example/GameViewController.m
@@ -62,13 +62,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         if (animationKeys.count > 0)
         {
             SCNScene* animation = [animScene animationSceneForKey:[animationKeys objectAtIndex:0]];            
-            [scene.modelScene addAnimationScene:animation];
-
-            /** You can also use the SCNNode category to add animation
-
-             [scene.modelScene.rootNode addAnimationScene:animation];
-
-             */
+            [scene.modelScene.rootNode addAnimationScene:animation];
         }
     }
 

--- a/appledoc.md
+++ b/appledoc.md
@@ -98,8 +98,7 @@ AssimpKit builds on top of the skeletal animation support provided by SceneKit.
 For any scene that contains skeletal animation data, it creates a skinner and
 sets it to the node whose geometry the skinner deforms. The animated scene after
 importing will contain a set of animations each with a unique animation key. You
-only have to add the animation to the scene to play it, without even worrying
-about which node to add the animation.
+only have to add the animation to the scene to play it.
 
 AssimpKit supports skeletal animations irrespective of whether they are defined
 in one animation file or multiple animation files.
@@ -128,7 +127,7 @@ animating, using the listing I-3 below.
     SCNScene *walkAnim = [scene animationSceneForKey:walkAnim];
 
     // add the walk animation to the boy model scene
-    [scene.modelScene addAnimation:attackAnim];
+    [scene.modelScene.rootNode addAnimation:attackAnim];
 
     // retrieve the SCNView
     SCNView *scnView = (SCNView *)self.view;
@@ -167,7 +166,7 @@ are animating, using the listing I-5 below.
     SCNScene *jumpStartAnim = [jumpStartScene animationSceneForKey:jumpId];
 
     // add the jump animation to the explorer scene
-    [scene.modelScene addAnimation:jumpStartAnim];
+    [scene.modelScene.rootNode addAnimation:jumpStartAnim];
 
     // retrieve the SCNView
     SCNView *scnView = (SCNView *)self.view;

--- a/docs/developer/design.rst
+++ b/docs/developer/design.rst
@@ -20,9 +20,7 @@ it generates a `scene kit node`_.
 `SCNAssimpScene`_ contains all the transformed data, excluding the animation
 data, for which `SCNAssimpAnimation`_ is the container. The `SCNAssimpScene`_
 generates the model `SCNScene`_ and animation `SCNScene`_ instances. The
-`SCNScene+AssimpImport`_ category also contains method to add the animation data in
-`SCNScene`_ to another `SCNScene`_ or `SCNNode`_.
-
+`SCNNode+AssimpImport`_ category contains method to add the animation.
 
 
 Generating the scene kit scene graph
@@ -162,11 +160,10 @@ integration into existing asset pipelines and/or applications becomes trivial.
 Loading Animations
 ==================
 
-The `SCNScene+AssimpImport`_ and `SCNNode+AssimpImport`_ category defines a
-method to add the animation data to a scene or node. As all the animation data
-is just `CAAnimation`_ objects, the animation `SCNScene`_ graph is traversed and
-the core animation objects are added to the corresponding bone node in the
-target scene or target nodes' subtree.
+The `SCNNode+AssimpImport`_ category defines a method to add the animation. As
+all the animation data is just `CAAnimation`_ objects, the animation `SCNScene`_
+graph is traversed and the core animation objects are added to the corresponding
+bone node in the target scene or target nodes' subtree.
 
 Testing
 =======

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -55,8 +55,8 @@ animations each represented by an ``SCNScene`` object. The `SCNAssimpScene`_
 also contains the key names for the animations which can be used when adding,
 removing animations.
 
-The ``AssimpImport`` category defined on `SCNScene+AssimpImport`_ and
-`SCNNode+AssimpImport`_ also contain a method to add a skeltal animation.
+The ``AssimpImport`` category defined on `SCNNode+AssimpImport`_ also contain a
+method to add a skeltal animation.
 
 For more information, refer to the :ref:`Tutorial`.
 

--- a/docs/user/tutorial.rst
+++ b/docs/user/tutorial.rst
@@ -77,6 +77,10 @@ only have to add the animation to the scene to play it.
 AssimpKit supports skeletal animations irrespective of whether they are defined
 in one animation file or multiple animation files.
 
+AssimpKit supports CAMediaTiming, animation attributes and animating scene kit
+content with an SCNAssimpAnimSettings class which you can (optionally) pass when
+adding an animation. You can set animation events and a delegate as well.
+
 Load an animation which is defined in the same file
 ---------------------------------------------------
 
@@ -87,6 +91,7 @@ animating, using the listing I-3 below.
 
     #import <AssimpKit/PostProcessing.h>
     #import <AssimpKit/SCNScene+AssimpImport.h>
+    #import <AssimpKit/SCNAssimpAnimSettings.h>
 
     // The path to the file path must not be a relative path
     NSString *boyPath = @"/of/assets/astroBoy_walk.dae";
@@ -99,12 +104,34 @@ animating, using the listing I-3 below.
                     postProcessFlags:AssimpKit_Process_FlipUVs |
                                      AssimpKit_Process_Triangulate]];
 
-    // get the animation which is defined in the same file
-    NSString *walkID = @"astroBoy_walk-1";
-    SCNScene *walkAnim = [scene animationSceneForKey:walkAnim];
-
     // add the walk animation to the boy model scene
-    [scene.modelScene.rootNode addAnimation:attackAnim];
+    // add an animation event as well as a delegate
+    SCNAssimpAnimSettings *settings =
+              [[SCNAssimpAnimSettings alloc] init];
+    settings.repeatCount = 3;
+
+    NSString *key = [scene.animationKeys objectAtIndex:0];
+    SCNAnimationEventBlock eventBlock =
+        ^(CAAnimation *animation, id animatedObject,
+          BOOL playingBackward) {
+            NSLog(@" Animation Event triggered ");
+            // You can remove the animation
+            // [scene.rootNode removeAnimationSceneForKey:key];
+        };
+    SCNAnimationEvent *animEvent =
+        [SCNAnimationEvent animationEventWithKeyTime:0.9f
+                                               block:eventBlock];
+    NSArray *animEvents =
+        [[NSArray alloc] initWithObjects:animEvent, nil];
+    settings.animationEvents = animEvents;
+
+    settings.delegate = self;
+
+    // get the animation which is defined in the same file
+    SCNScene *animation = [animScene animationSceneForKey:key];
+    [scene.modelScene.rootNode addAnimationScene:animation
+                                          forKey:key
+                                    withSettings:settings];
 
     // retrieve the SCNView
     SCNView *scnView = (SCNView *)self.view;
@@ -146,7 +173,10 @@ are animating, using the listing I-5 below.
     SCNScene *jumpStartAnim = [jumpStartScene animationSceneForKey:jumpId];
 
     // add the jump animation to the explorer scene
-    [scene.modelScene.rootNode addAnimation:jumpStartAnim];
+    // use the default settings, for custom settings see previous listing I-4
+    [scene.modelScene.rootNode addAnimation:jumpStartAnim
+                                     forKey:jumpId
+                               withSettings:nil];
 
     // retrieve the SCNView
     SCNView *scnView = (SCNView *)self.view;
@@ -154,38 +184,11 @@ are animating, using the listing I-5 below.
     // set the model scene to the view
     scnView.scene = scene.modelScene;
 
-Adding an animation to a node
------------------------------
-
-You can also add an animation to a node, using the SCNNode(AssimpImport) category.
-
-*Listing I-5: Load and play an animation added to SCNNode*::
-
-    #import <AssimpKit/PostProcessing.h>
-    #import <AssimpKit/SCNScene+AssimpImport.h>
-
-    // Some node somewhere to which you add the animation
-    SCNNode *targetNode = ...
-    
-    // load an animation which is defined in a separate file
-    NSString *jumpAnim = @"/explorer/jump_start.dae"];
-    SCNAssimpScene *jumpStartScene =
-        [SCNAssimpScene assimpSceneWithURL:[NSURL URLWithString:jumpAnim]
-                          postProcessFlags:AssimpKit_Process_FlipUVs |
-                                           AssimpKit_Process_Triangulate];
-
-    // get the aniamtion with animation key
-    NSString *jumpId = @"jump_start-1";
-    SCNScene *jumpStartAnim = [jumpStartScene animationSceneForKey:jumpId];
-
-    // add the jump animation to the explorer scene
-    [targetNode addAnimation:jumpStartAnim];
-
-Removing Animations
+Managing Animations
 -------------------
 
-You can use the `removeAllAnimations`_ method defined in `SCNAnimatable`_ to
-remove all animations attached to the object, using AssimpKit.
+The SCNNode+AssimpImport category simulates the SCNAnimatable protocol and
+provides methods to attach, remove, pause and resume animations.
 
 Serialization and integrating with asset pipeline
 =================================================
@@ -216,10 +219,17 @@ exported to ``Bob-1.scn``, then in some ``iOS/macOS`` app,
 you can load these and play the animation as such.::
 
      #import <AssimpKit/SCNScene+AssimpImport.h>
+     #import <AssimpKit/SCNAssimpAnimSettings.h>
 
      SCNScene *scene = [SCNScene sceneNamed:@"art.scnassets/Bob.scn"];
      SCNScene *animScene = [SCNScene sceneNamed:@"art.scnassets/Bob-1.scn"];
-     [scene addAnimationScene:animScene];
+
+     SCNAssimpAnimSettings * settings = [[SCNAssimpAnimSettings alloc] init];
+     settings.repeatCount = 3;
+     [scene.rootNode addAnimationScene:animScene
+                                forKey:@"Bob-1"
+                          withSettings:settings];
+
 
 You can see below the ``Bob.scn`` file edited in XCode Scene editor.
 

--- a/docs/user/tutorial.rst
+++ b/docs/user/tutorial.rst
@@ -72,8 +72,7 @@ AssimpKit builds on top of the skeletal animation support provided by SceneKit.
 For any scene that contains skeletal animation data, it creates a skinner and
 sets it to the node whose geometry the skinner deforms. The animated scene after
 importing will contain a set of animations each with a unique animation key. You
-only have to add the animation to the scene to play it, without even worrying
-about which node to add the animation.
+only have to add the animation to the scene to play it.
 
 AssimpKit supports skeletal animations irrespective of whether they are defined
 in one animation file or multiple animation files.
@@ -105,7 +104,7 @@ animating, using the listing I-3 below.
     SCNScene *walkAnim = [scene animationSceneForKey:walkAnim];
 
     // add the walk animation to the boy model scene
-    [scene.modelScene addAnimation:attackAnim];
+    [scene.modelScene.rootNode addAnimation:attackAnim];
 
     // retrieve the SCNView
     SCNView *scnView = (SCNView *)self.view;
@@ -147,7 +146,7 @@ are animating, using the listing I-5 below.
     SCNScene *jumpStartAnim = [jumpStartScene animationSceneForKey:jumpId];
 
     // add the jump animation to the explorer scene
-    [scene.modelScene addAnimation:jumpStartAnim];
+    [scene.modelScene.rootNode addAnimation:jumpStartAnim];
 
     // retrieve the SCNView
     SCNView *scnView = (SCNView *)self.view;


### PR DESCRIPTION
This adds support for `CAMediaTiming`, animation attributes and `SCNAnimatable` with an `SCNAssimpAnimSettings` class which contains the animation properties and updating the `SCNNode+AssimpImport` category for `SCNAnimatable` support. 

The `addAnimationScene` category method now can be passed the animation key for later retrieval to delete, pause, resume and the animation settings object.

Fixes #47 