### PR TITLE
Fix 7z

### DIFF
--- a/AssimpKit/Library/Library.xcodeproj/xcshareddata/xcschemes/AssimpKit-iOS.xcscheme
+++ b/AssimpKit/Library/Library.xcodeproj/xcshareddata/xcschemes/AssimpKit-iOS.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "#!/bin/sh&#10;echo Extracting iOS fat lib...&#10;cd $PROJECT_DIR&#10;rm $PROJECT_DIR/../Assimp/lib/ios/libassimp-fat.a&#10;7z x $PROJECT_DIR/../Assimp/lib/ios/libassimp-fat.7z&#10;mv $PROJECT_DIR/libassimp-fat.a $PROJECT_DIR/../Assimp/lib/ios/">
+               scriptText = "#!/bin/sh&#10;echo Extracting iOS fat lib...&#10;if ! [ -x &quot;$(command -v 7z)&quot; ]; then&#10;  echo &apos;error: 7z is not installed.&apos; &gt;&amp;2&#10;  echo &apos;fix: Install 7z with brew ...&apos; &gt;&amp;2&#10;  echo &apos;fix: Please run: brew install p7zip&apos; &gt;&amp;2&#10;  exit 1&#10;fi&#10;cd $PROJECT_DIR&#10;rm $PROJECT_DIR/../Assimp/lib/ios/libassimp-fat.a&#10;7z x $PROJECT_DIR/../Assimp/lib/ios/libassimp-fat.7z&#10;mv $PROJECT_DIR/libassimp-fat.a $PROJECT_DIR/../Assimp/lib/ios/">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "#!/bin/sh&#10;echo Extracting iOS fat lib...&#10;cd $PROJECT_DIR&#10;rm $PROJECT_DIR/../Assimp/lib/ios/libIrrXML-fat.a&#10;7z x $PROJECT_DIR/../Assimp/lib/ios/libIrrXML-fat.7z&#10;mv $PROJECT_DIR/libIrrXML-fat.a $PROJECT_DIR/../Assimp/lib/ios/">
+               scriptText = "#!/bin/sh&#10;echo Extracting iOS fat lib...&#10;if ! [ -x &quot;$(command -v 7z)&quot; ]; then&#10;  echo &apos;error: 7z is not installed.&apos; &gt;&amp;2&#10;  echo &apos;fix: Install 7z with brew ...&apos; &gt;&amp;2&#10;  echo &apos;fix: Please run: brew install p7zip&apos; &gt;&amp;2&#10;  exit 1&#10;fi&#10;cd $PROJECT_DIR&#10;rm $PROJECT_DIR/../Assimp/lib/ios/libIrrXML-fat.a&#10;7z x $PROJECT_DIR/../Assimp/lib/ios/libIrrXML-fat.7z&#10;mv $PROJECT_DIR/libIrrXML-fat.a $PROJECT_DIR/../Assimp/lib/ios/">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/AssimpKit/Library/Library.xcodeproj/xcshareddata/xcschemes/AssimpKit-macOS.xcscheme
+++ b/AssimpKit/Library/Library.xcodeproj/xcshareddata/xcschemes/AssimpKit-macOS.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "#!/bin/sh&#10;echo Extracting macOS fat lib...&#10;cd $PROJECT_DIR&#10;rm $PROJECT_DIR/../Assimp/lib/osx/libassimp.a&#10;7z x $PROJECT_DIR/../Assimp/lib/osx/libassimp.7z&#10;mv $PROJECT_DIR/libassimp.a $PROJECT_DIR/../Assimp/lib/osx/">
+               scriptText = "#!/bin/sh&#10;echo Extracting macOS fat lib...&#10;if ! [ -x &quot;$(command -v 7z)&quot; ]; then&#10;  echo &apos;error: 7z is not installed.&apos; &gt;&amp;2&#10;  echo &apos;fix: Install 7z with brew ...&apos; &gt;&amp;2&#10;  echo &apos;fix: Please run: brew install p7zip&apos; &gt;&amp;2&#10;  exit 1&#10;fi&#10;cd $PROJECT_DIR&#10;rm $PROJECT_DIR/../Assimp/lib/osx/libassimp.a&#10;7z x $PROJECT_DIR/../Assimp/lib/osx/libassimp.7z&#10;mv $PROJECT_DIR/libassimp.a $PROJECT_DIR/../Assimp/lib/osx/">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "#!/bin/sh&#10;echo Extracting macOS fat lib...&#10;cd $PROJECT_DIR&#10;rm $PROJECT_DIR/../Assimp/lib/osx/libIrrXML.a&#10;7z x $PROJECT_DIR/../Assimp/lib/osx/libIrrXML.7z&#10;mv $PROJECT_DIR/libIrrXML.a $PROJECT_DIR/../Assimp/lib/osx/">
+               scriptText = "#!/bin/sh&#10;echo Extracting macOS fat lib...&#10;if ! [ -x &quot;$(command -v 7z)&quot; ]; then&#10;  echo &apos;error: 7z is not installed.&apos; &gt;&amp;2&#10;  echo &apos;fix: Install 7z with brew ...&apos; &gt;&amp;2&#10;  echo &apos;fix: Please run: brew install p7zip&apos; &gt;&amp;2&#10;  exit 1&#10;fi&#10;cd $PROJECT_DIR&#10;rm $PROJECT_DIR/../Assimp/lib/osx/libIrrXML.a&#10;7z x $PROJECT_DIR/../Assimp/lib/osx/libIrrXML.7z&#10;mv $PROJECT_DIR/libIrrXML.a $PROJECT_DIR/../Assimp/lib/osx/">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/README.md
+++ b/README.md
@@ -47,8 +47,32 @@ Requirements
 - ObjC 2.0
 - iOS 10.0 or later
 - macOS 10.11 or later
+- 7z
 
 Installation with Carthage (iOS 10.0+, macOS 10.11+)
+---
+
+---
+1. PreRequiste: Install 7z
+---
+
+The build process depends on 7z to extract static library archives. Please ensure 7z is installed.
+
+You can check if 7z is installed with:
+
+```
+type 7z
+```
+command on the Terminal.
+
+To install, you can use brew as such:
+
+```
+brew update && brew install p7zip
+```
+
+---
+2. Using Carthage
 ---
 
 [Carthage](https://github.com/Carthage/Carthage) is a lightweight dependency
@@ -68,7 +92,8 @@ After `carthage update`, add the appropriate platform framework (iOS, macOS) to
 your project. The frameworks are placed in `iOS` and `Mac` subdirectories under
 the `Carthage/Build` directory of your project.
 
-Important Build Setting for `iOS` applications only
+---
+3. Important Build Setting for `iOS` applications only
 ---
 
 If you are developing an `iOS` application, set the `Enable Bitcode` under `Build Settings->Build Options` of your target to `NO`.

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -11,8 +11,31 @@ Requirements
 
 .. _installation-label:
 
+
+
 Installation
 ============
+
+PreRequiste: Install 7z
+-----------------------
+
+The build process depends on 7z to extract static library archives. Please ensure 7z is installed.
+
+You can check if 7z is installed with:
+
+```
+type 7z
+```
+command on the Terminal.
+
+To install, you can use brew as such:
+
+```
+brew update && brew install p7zip
+```
+
+Using Carthage
+--------------
 
 AssimpKit is `Carthage`_ compatible.
 


### PR DESCRIPTION
Fixes #73 

The pre install scripts now check if 7z is installed, else exit with status code 1. However, xcodebuild fails at a later stage, so one needs to scan the output to check for the 7z failure reporting. Yikes :-(. The same for Carthage logs.