### PR TITLE
Ensure resources can be accessed in secure envs

### DIFF
--- a/AssimpKit/Code/Model/SCNTextureInfo.m
+++ b/AssimpKit/Code/Model/SCNTextureInfo.m
@@ -270,8 +270,10 @@
 {
     DLog(@" Generating external texture");
     NSURL *imageURL = [NSURL fileURLWithPath:path];
+    [imageURL startAccessingSecurityScopedResource];
     self.imageSource = CGImageSourceCreateWithURL((CFURLRef)imageURL, NULL);
     self.image = CGImageSourceCreateImageAtIndex(self.imageSource, 0, NULL);
+    [imageURL stopAccessingSecurityScopedResource];
 }
 
 #pragma mark - Extract color


### PR DESCRIPTION
If you try to access texture resources where the source file is in a secured env, ensure that the the resource is accessed in a secure scope.