### PR TITLE
Preserve material name

### DIFF
--- a/AssimpKit/Code/Model/AssimpImporter.m
+++ b/AssimpKit/Code/Model/AssimpImporter.m
@@ -806,10 +806,11 @@ makeIndicesGeometryElementForMeshIndex:(int)aiMeshIndex
             aiScene->mMaterials[aiMesh->mMaterialIndex];
         struct aiString name;
         aiGetMaterialString(aiMaterial, AI_MATKEY_NAME, &name);
-        DLog(
-            @" Material name is %@",
-            [NSString stringWithUTF8String:(const char *_Nonnull) & name.data]);
+        NSString *nameString = [NSString stringWithUTF8String:
+                                (const char *_Nonnull) & name.data];
+        DLog(@" Material name is %@", name);
         SCNMaterial *material = [SCNMaterial material];
+        material.name = nameString;
         int kTextureTypes = 10;
         int textureTypes[10] = {
             aiTextureType_DIFFUSE,      aiTextureType_SPECULAR,


### PR DESCRIPTION
Hey @dmsurti !

I need `aiMaterial` name to be preserved in `SCNMaterial` so I can group those materials later.