### PR TITLE
Support for vertex colors.

### DIFF
--- a/AssimpKit/Code/Model/AssimpImporter.m
+++ b/AssimpKit/Code/Model/AssimpImporter.m
@@ -537,6 +537,50 @@ makeTextureGeometrySourceForNode:(const struct aiNode *)aiNode
 }
 
 /**
+ Creates a scenekit vertex color source from the vertex color information of
+ the specified node.
+ 
+ @param aiNode The assimp node.
+ @param aiScene The assimp scene.
+ @param nVertices The number of vertices in the meshes of the node.
+ @return A new color source whose semantic property is vertex color.
+ */
+- (SCNGeometrySource *)
+makeColorGeometrySourceForNode:(const struct aiNode *)aiNode
+inScene:(const struct aiScene *)aiScene
+withNVertices:(int)nVertices
+{
+    float* scnColors = (float*)malloc(nVertices * 3 * sizeof(float));
+    int colorsCounter = 0;
+    
+    for (int i = 0; i < aiNode->mNumMeshes; i++) {
+        int aiMeshIndex = aiNode->mMeshes[i];
+        const struct aiMesh *aiMesh = aiScene->mMeshes[aiMeshIndex];
+        const struct aiColor4D *aiColor4D = aiMesh->mColors[0];
+        
+        if (aiColor4D == NULL) { return NULL; }
+        
+        for (int j = 0; j < nVertices; j++) {
+            scnColors[colorsCounter++] = aiColor4D[j].r;
+            scnColors[colorsCounter++] = aiColor4D[j].g;
+            scnColors[colorsCounter++] = aiColor4D[j].b;
+        }
+    }
+    
+    SCNGeometrySource *colorSource = [SCNGeometrySource
+                                      geometrySourceWithData:[NSData dataWithBytes:scnColors length:nVertices * 3 * sizeof(float)]
+                                      semantic:SCNGeometrySourceSemanticColor
+                                      vectorCount:nVertices
+                                      floatComponents:YES
+                                      componentsPerVector:3
+                                      bytesPerComponent:sizeof(float)
+                                      dataOffset:0
+                                      dataStride:3 * sizeof(float)];
+    free(scnColors);
+    return colorSource;
+}
+
+/**
  Creates an array of geometry sources for the specifed node describing
  the vertices in the geometry and their attributes.
 
@@ -566,6 +610,14 @@ makeTextureGeometrySourceForNode:(const struct aiNode *)aiNode
         addObject:[self makeTextureGeometrySourceForNode:aiNode
                                                  inScene:aiScene
                                            withNVertices:nVertices]];
+    
+    SCNGeometrySource *colorGeometrySource = [self makeColorGeometrySourceForNode:aiNode
+                                                                          inScene:aiScene
+                                                                    withNVertices:nVertices];
+    if (colorGeometrySource != nil) {
+        [scnGeometrySources addObject: colorGeometrySource];
+    }
+    
     return scnGeometrySources;
 }
 


### PR DESCRIPTION
Adds geometry source with semantic `SCNGeometrySourceSemanticColor` if a mesh has vertex colors specified.